### PR TITLE
Build against latest bindgen output

### DIFF
--- a/src/high/mod.rs
+++ b/src/high/mod.rs
@@ -68,7 +68,7 @@
 //!
 //! Invoking the closure a second time will panic.
 
-pub use middle::{FfiAbi, FFI_DEFAULT_ABI};
+pub use middle::{FfiAbi, ffi_abi_FFI_DEFAULT_ABI};
 
 pub mod types;
 pub use self::types::{Type, CType};

--- a/src/low.rs
+++ b/src/low.rs
@@ -115,7 +115,7 @@ impl CodePtr {
     }
 }
 
-pub use raw::{ffi_abi, FFI_DEFAULT_ABI, _ffi_type as ffi_type, ffi_status,
+pub use raw::{ffi_abi, ffi_abi_FFI_DEFAULT_ABI, _ffi_type as ffi_type, ffi_status,
               ffi_cif, ffi_closure};
 
 /// Re-exports the `ffi_type` objects used to describe the types of
@@ -235,7 +235,7 @@ pub mod type_tag {
 /// let mut cif: ffi_cif = Default::default();
 ///
 /// unsafe {
-///     prep_cif(&mut cif, FFI_DEFAULT_ABI, 2,
+///     prep_cif(&mut cif, ffi_abi_FFI_DEFAULT_ABI, 2,
 ///              &mut types::pointer, args.as_mut_ptr())
 /// }.unwrap();
 /// ```
@@ -320,7 +320,7 @@ pub unsafe fn prep_cif_var(cif: *mut ffi_cif,
 ///                                              &mut types::uint64 ];
 ///     let mut cif: ffi_cif = Default::default();
 ///
-///     prep_cif(&mut cif, FFI_DEFAULT_ABI, 2,
+///     prep_cif(&mut cif, ffi_abi_FFI_DEFAULT_ABI, 2,
 ///              &mut types::uint64, args.as_mut_ptr()).unwrap();
 ///
 ///     call(&mut cif, CodePtr(c_function as *mut _),
@@ -476,7 +476,7 @@ pub type RawCallback
 ///     let mut args = [&mut types::uint64 as *mut _];
 ///     let mut userdata: u64 = 5;
 ///
-///     prep_cif(&mut cif, FFI_DEFAULT_ABI, 1, &mut types::uint64,
+///     prep_cif(&mut cif, ffi_abi_FFI_DEFAULT_ABI, 1, &mut types::uint64,
 ///              args.as_mut_ptr()).unwrap();
 ///
 ///     let (closure, code) = closure_alloc();
@@ -568,7 +568,7 @@ pub unsafe fn prep_closure<U, R>(closure:  *mut ffi_closure,
 ///     let mut args = [&mut types::uint64 as *mut _];
 ///     let mut userdata: u64 = 5;
 ///
-///     prep_cif(&mut cif, FFI_DEFAULT_ABI, 1, &mut types::uint64,
+///     prep_cif(&mut cif, ffi_abi_FFI_DEFAULT_ABI, 1, &mut types::uint64,
 ///              args.as_mut_ptr()).unwrap();
 ///
 ///     let (closure, code) = closure_alloc();

--- a/src/middle/builder.rs
+++ b/src/middle/builder.rs
@@ -5,7 +5,7 @@ use super::types::Type;
 /// Provides a builder-style API for constructing CIFs and closures.
 ///
 /// To use a builder, first construct it using [`Builder::new`](#method.new).
-/// The default calling convention is `FFI_DEFAULT_ABI`, and the default
+/// The default calling convention is `ffi_abi_FFI_DEFAULT_ABI`, and the default
 /// function type is `extern "C" fn()` (or in C, `void(*)()`). Add
 /// argument types to the function type with the [`arg`](#method.arg)
 /// and [`args`](#method.args) methods. Set the result type with
@@ -75,7 +75,7 @@ impl Builder {
         Builder {
             args: vec![],
             res: Type::void(),
-            abi: super::FFI_DEFAULT_ABI,
+            abi: super::ffi_abi_FFI_DEFAULT_ABI,
         }
     }
 

--- a/src/middle/mod.rs
+++ b/src/middle/mod.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 
 use low;
 pub use low::{Callback, CallbackMut, CodePtr,
-              ffi_abi as FfiAbi, FFI_DEFAULT_ABI};
+              ffi_abi as FfiAbi, ffi_abi_FFI_DEFAULT_ABI};
 
 #[cfg(not(feature = "unique"))]
 mod util;
@@ -123,7 +123,7 @@ impl Cif {
 
         unsafe {
             low::prep_cif(&mut cif,
-                          low::FFI_DEFAULT_ABI,
+                          low::ffi_abi_FFI_DEFAULT_ABI,
                           nargs,
                           result.as_raw_ptr(),
                           args.as_raw_ptr())


### PR DESCRIPTION
Some of the names of variables seems to have changed in the latest bindgen build.