### PR TITLE
Feat: ARMv7 support

### DIFF
--- a/src/low.rs
+++ b/src/low.rs
@@ -130,14 +130,10 @@ pub use raw::{ffi_abi, ffi_abi_FFI_DEFAULT_ABI, ffi_cif, ffi_closure, ffi_status
 /// becomes `low::types::void`.
 pub mod types {
     pub use crate::raw::{
-        ffi_type_double as double, ffi_type_double as double, ffi_type_float as float,
-        ffi_type_float as float, ffi_type_longdouble as longdouble, ffi_type_pointer as pointer,
-        ffi_type_pointer as pointer, ffi_type_sint16 as sint16, ffi_type_sint16 as sint16,
-        ffi_type_sint32 as sint32, ffi_type_sint32 as sint32, ffi_type_sint64 as sint64,
-        ffi_type_sint64 as sint64, ffi_type_sint8 as sint8, ffi_type_sint8 as sint8,
-        ffi_type_uint16 as uint16, ffi_type_uint16 as uint16, ffi_type_uint32 as uint32,
-        ffi_type_uint32 as uint32, ffi_type_uint64 as uint64, ffi_type_uint64 as uint64,
-        ffi_type_uint8 as uint8, ffi_type_uint8 as uint8, ffi_type_void as void,
+        ffi_type_double as double, ffi_type_float as float, ffi_type_pointer as pointer,
+        ffi_type_sint16 as sint16, ffi_type_sint32 as sint32, ffi_type_sint64 as sint64,
+        ffi_type_sint8 as sint8, ffi_type_uint16 as uint16, ffi_type_uint32 as uint32,
+        ffi_type_uint64 as uint64, ffi_type_uint8 as uint8, ffi_type_void as void,
     };
 
     #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]

--- a/src/low.rs
+++ b/src/low.rs
@@ -136,7 +136,7 @@ pub mod types {
         ffi_type_uint64 as uint64, ffi_type_uint8 as uint8, ffi_type_void as void,
     };
 
-    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
+    #[cfg(not(all(target_arch = "arm")))]
     pub use crate::raw::ffi_type_longdouble as longdouble;
 
     #[cfg(feature = "complex")]
@@ -145,7 +145,7 @@ pub mod types {
     };
 
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
+    #[cfg(not(all(target_arch = "arm")))]
     pub use crate::raw::ffi_type_complex_longdouble as complex_longdouble;
 }
 

--- a/src/low.rs
+++ b/src/low.rs
@@ -140,6 +140,10 @@ pub mod types {
         ffi_type_float as float,
         ffi_type_double as double,
         ffi_type_pointer as pointer,
+    };
+
+    #[cfg(not(all(target_arch = "arm", target_os="linux", target_env="gnu")))]
+    pub use crate::raw::{
         ffi_type_longdouble as longdouble
     };
 
@@ -147,6 +151,11 @@ pub mod types {
     pub use crate::raw::{
         ffi_type_complex_float as complex_float,
         ffi_type_complex_double as complex_double,
+    };
+
+    #[cfg(feature = "complex")]
+    #[cfg(not(all(target_arch = "arm", target_os="linux", target_env="gnu")))]
+    pub use crate::raw::{
         ffi_type_complex_longdouble as complex_longdouble
     };
 }

--- a/src/low.rs
+++ b/src/low.rs
@@ -136,7 +136,7 @@ pub mod types {
         ffi_type_uint64 as uint64, ffi_type_uint8 as uint8, ffi_type_void as void,
     };
 
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
     pub use crate::raw::ffi_type_longdouble as longdouble;
 
     #[cfg(feature = "complex")]
@@ -145,7 +145,7 @@ pub mod types {
     };
 
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
     pub use crate::raw::ffi_type_complex_longdouble as complex_longdouble;
 }
 

--- a/src/middle/mod.rs
+++ b/src/middle/mod.rs
@@ -78,8 +78,8 @@ pub fn arg<T>(r: &T) -> Arg {
 /// let args = vec![Type::f64(), Type::pointer()];
 /// let cif = Cif::new(args.into_iter(), Type::f64());
 ///
-/// let n = unsafe { cif.call(CodePtr(add as *mut _), &[arg(&5), arg(&&6)]) };
-/// assert_eq!(11, n);
+/// let n = unsafe { cif.call(CodePtr(add as *mut _), &[arg(&5f64), arg(&&6f64)]) };
+/// assert_eq!(11f64, n);
 /// ```
 #[derive(Debug)]
 pub struct Cif {

--- a/src/middle/types.rs
+++ b/src/middle/types.rs
@@ -368,7 +368,7 @@ impl Type {
     }
 
     /// Returns the C `long double` (extended-precision floating point) type.
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
     pub fn longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::longdouble) })
     }
@@ -393,7 +393,7 @@ impl Type {
     ///
     /// This item is enabled by `#[cfg(feature = "complex")]`.
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
+    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
     pub fn complex_longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::complex_longdouble) })
     }

--- a/src/middle/types.rs
+++ b/src/middle/types.rs
@@ -368,7 +368,7 @@ impl Type {
     }
 
     /// Returns the C `long double` (extended-precision floating point) type.
-    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
+    #[cfg(not(all(target_arch = "arm")))]
     pub fn longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::longdouble) })
     }
@@ -393,7 +393,7 @@ impl Type {
     ///
     /// This item is enabled by `#[cfg(feature = "complex")]`.
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux")))]
+    #[cfg(not(all(target_arch = "arm")))]
     pub fn complex_longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::complex_longdouble) })
     }

--- a/src/middle/types.rs
+++ b/src/middle/types.rs
@@ -370,6 +370,7 @@ impl Type {
     }
 
     /// Returns the C `long double` (extended-precision floating point) type.
+    #[cfg(not(all(target_arch = "arm", target_os="linux", target_env="gnu")))]
     pub fn longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::longdouble) })
     }
@@ -394,6 +395,7 @@ impl Type {
     ///
     /// This item is enabled by `#[cfg(feature = "complex")]`.
     #[cfg(feature = "complex")]
+    #[cfg(not(all(target_arch = "arm", target_os="linux", target_env="gnu")))]
     pub fn complex_longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::complex_longdouble) })
     }


### PR DESCRIPTION
- Allows libffi-rs to build for Raspberry Pi and other ARMv7 targets that don't have `longdouble`
- Fixes a failing test on Windows