### PR TITLE
Improve portability of libffi-sys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,31 @@ jobs:
       matrix:
         channel: [1.36.0, stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
+        target:
+        - x86_64-unknown-linux-gnu
+        - i686-unknown-linux-gnu
+        - powerpc64le-unknown-linux-gnu
+        - powerpc64-unknown-linux-gnu
+        - aarch64-unknown-linux-gnu
+        - armv7-unknown-linux-gnueabihf
+        exclude:
+        # Don't try to build with `--features system` when cross-compiling
+        # It's probably possible to make this work for some of these architectures
+        # (e.g. I got it working on my Ubuntu image for i686), but it complicates
+        # testing a bit
+        - target: i686-unknown-linux-gnu
+          features: "--features system"
+        - target: powerpc64le-unknown-linux-gnu
+          features: "--features system"
+        - target: powerpc64-unknown-linux-gnu
+          features: "--features system"
+        - target: aarch64-unknown-linux-gnu
+          features: "--features system"
+        - target: armv7-unknown-linux-gnueabihf
+          features: "--features system"
+
     runs-on: ubuntu-latest
-    name: Linux - ${{ matrix.channel }} ${{ matrix.features }}
+    name: Linux - ${{ matrix.channel }} ${{ matrix.features }} ${{ matrix.target }}
     env:
       RUST_BACKTRACE: 1
     steps:
@@ -125,14 +148,61 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.channel }}
+          target: ${{ matrix.target }}
           override: true
           profile: minimal
           default: true
+      - name: Set-up Cross Compiling
+        id: arch_attrs
+        run: |
+          # Get unique attributes for each architecture
+          if [ "${{ matrix.target }}" == "i686-unknown-linux-gnu" ]; then
+            GCC_ARCH=i686
+            ABI=gnu
+          elif [ "${{ matrix.target }}" == "powerpc64-unknown-linux-gnu" ]; then
+            GCC_ARCH=powerpc64
+            QEMU_ARCH=ppc64
+            ABI=gnu
+          elif [ "${{ matrix.target }}" == "powerpc64le-unknown-linux-gnu" ]; then
+            GCC_ARCH=powerpc64le
+            QEMU_ARCH=ppc64le
+            ABI=gnu
+          elif [ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]; then
+            GCC_ARCH=aarch64
+            QEMU_ARCH=aarch64
+            ABI=gnu
+          elif [ "${{ matrix.target }}" == "armv7-unknown-linux-gnueabihf" ]; then
+            GCC_ARCH=arm
+            QEMU_ARCH=arm
+            ABI=gnueabihf
+          fi
+
+          # Install cross-compiler
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc-8-$(echo $GCC_ARCH | tr _ -)-linux-$ABI
+          
+          # Convert target triple to uppercase and replace - with _
+          TARGET_TRIPLE=$(echo "${{ matrix.target }}" | tr - _)
+          TARGET_TRIPLE=${TARGET_TRIPLE^^}
+
+          CC=$GCC_ARCH-linux-$ABI-gcc-8
+
+          # Set cross-compiler as CC and set cargo target runner as qemu
+          echo "CC=$CC" >> $GITHUB_ENV
+          echo "CARGO_TARGET_${TARGET_TRIPLE}_LINKER=$CC" >> $GITHUB_ENV
+
+          # Don't need QEMU for i686
+          if [ "$QEMU_ARCH" != "" ]; then
+            sudo apt-get install -y qemu-user
+            echo "CARGO_TARGET_${TARGET_TRIPLE}_RUNNER=qemu-$QEMU_ARCH -L /usr/$GCC_ARCH-linux-$ABI/" >> $GITHUB_ENV
+          fi
+        if: ${{ 'x86_64-unknown-linux-gnu' != matrix.target }}
       - name: Test libffi-sys-rs
         run: |
           cd libffi-sys-rs
-          cargo test ${{ matrix.features }}
+          cargo test --target ${{ matrix.target }} ${{ matrix.features }}
       - name: Test libffi-rs
         run: |
           cd libffi-rs
-          cargo test ${{ matrix.features }}
+          cargo test --target ${{ matrix.target }} ${{ matrix.features }}

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -50,8 +50,14 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
     command
         .arg("configure")
         .arg("--with-pic")
-        .arg("--disable-docs")
-        .current_dir(&build_dir);
+        .arg("--disable-docs");
+
+    let target = std::env::var("TARGET").unwrap();
+    if target != std::env::var("HOST").unwrap() {
+        command.arg(format!("--host={}", target.to_string()));
+    }
+
+    command.current_dir(&build_dir);
 
     if cfg!(windows) {
         // When using MSYS2, OUT_DIR will be a Windows like path such as

--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -1,0 +1,294 @@
+//! This module defines the different ffi_abi values for each platform.
+//!
+//! This module is set-up to define all the constants for each platform, but only export those which
+//! are actually relevant to the target arch. This is done as a compile check to ensure the code
+//! paths in less utilized architectures largely continue to compile.
+
+#![allow(unused)]
+
+/// From libffi:src/x86/ffitarget.h
+/// See: https://github.com/libffi/libffi/blob/369ef49f71186fc9d6ab15614488ad466fac3fc1/src/x86/ffitarget.h#L80
+mod x86 {
+    pub mod x86_win64 {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_WIN64: ffi_abi = 1;
+        pub const ffi_abi_FFI_GNUW64: ffi_abi = 2;
+        pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 3;
+
+        mod gnu {
+            pub const ffi_abi_FFI_DEFAULT_ABI: crate::ffi_abi = super::ffi_abi_FFI_GNUW64;
+        }
+
+        mod msvc {
+            pub const ffi_abi_FFI_DEFAULT_ABI: crate::ffi_abi = super::ffi_abi_FFI_GNUW64;
+        }
+
+        #[cfg(target_env = "gnu")]
+        pub use gnu::*;
+        #[cfg(target_env = "msvc")]
+        pub use msvc::*;
+
+        // See: https://github.com/libffi/libffi/blob/369ef49f71186fc9d6ab15614488ad466fac3fc1/src/x86/ffitarget.h#L137
+        pub const FFI_TRAMPOLINE_SIZE: usize = 24;
+        pub const FFI_NATIVE_RAW_API: u32 = 0;
+    }
+
+    pub mod x86_64 {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 1;
+        pub const ffi_abi_FFI_UNIX64: ffi_abi = 2;
+        pub const ffi_abi_FFI_WIN64: ffi_abi = 3;
+        pub const ffi_abi_FFI_EFI64: ffi_abi = ffi_abi_FFI_WIN64;
+        pub const ffi_abi_FFI_GNUW64: ffi_abi = 4;
+        pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 5;
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_UNIX64;
+
+        // See: https://github.com/libffi/libffi/blob/369ef49f71186fc9d6ab15614488ad466fac3fc1/src/x86/ffitarget.h#L137
+        pub const FFI_TRAMPOLINE_SIZE: usize = 24;
+        pub const FFI_NATIVE_RAW_API: u32 = 0;
+    }
+
+    pub mod x86_win32 {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_SYSV: ffi_abi = 1;
+        pub const ffi_abi_FFI_STDCALL: ffi_abi = 2;
+        pub const ffi_abi_FFI_THISCALL: ffi_abi = 3;
+        pub const ffi_abi_FFI_FASTCALL: ffi_abi = 4;
+        pub const ffi_abi_FFI_MS_CDECL: ffi_abi = 5;
+        pub const ffi_abi_FFI_PASCAL: ffi_abi = 6;
+        pub const ffi_abi_FFI_REGISTER: ffi_abi = 7;
+        pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 8;
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_MS_CDECL;
+
+        // See: https://github.com/libffi/libffi/blob/369ef49f71186fc9d6ab15614488ad466fac3fc1/src/x86/ffitarget.h#L137
+        pub const FFI_TRAMPOLINE_SIZE: usize = 12;
+        pub const FFI_NATIVE_RAW_API: u32 = 1;
+    }
+
+    pub mod x86 {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_SYSV: ffi_abi = 1;
+        pub const ffi_abi_FFI_THISCALL: ffi_abi = 3;
+        pub const ffi_abi_FFI_FASTCALL: ffi_abi = 4;
+        pub const ffi_abi_FFI_STDCALL: ffi_abi = 5;
+        pub const ffi_abi_FFI_PASCAL: ffi_abi = 6;
+        pub const ffi_abi_FFI_REGISTER: ffi_abi = 7;
+        pub const ffi_abi_FFI_MS_CDECL: ffi_abi = 8;
+        pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 9;
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_SYSV;
+
+        // See: https://github.com/libffi/libffi/blob/369ef49f71186fc9d6ab15614488ad466fac3fc1/src/x86/ffitarget.h#L137
+        pub const FFI_TRAMPOLINE_SIZE: usize = 12;
+        pub const FFI_NATIVE_RAW_API: u32 = 1;
+    }
+
+    pub const FFI_GO_CLOSURES: u32 = 1;
+}
+
+#[cfg(all(target_arch = "x86_64", windows))]
+pub use x86::x86_win64::*;
+
+#[cfg(all(target_arch = "x86_64", unix))]
+pub use x86::x86_64::*;
+
+#[cfg(all(target_arch = "x86", windows))]
+pub use x86::x86_win32::*;
+
+#[cfg(all(target_arch = "x86", unix))]
+pub use x86::x86::*;
+
+/// From libffi:src/arm/ffitarget.h
+/// See: https://github.com/libffi/libffi/blob/db5706ff285c476aa3c0f811ff2b188319ac3ebe/src/arm/ffitarget.h
+mod arm {
+    use crate::ffi_abi;
+
+    pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+    pub const ffi_abi_FFI_SYSV: ffi_abi = 1;
+    pub const ffi_abi_FFI_VFP: ffi_abi = 2;
+    pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 3;
+    pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_SYSV;
+
+    // See: https://github.com/libffi/libffi/blob/db5706ff285c476aa3c0f811ff2b188319ac3ebe/src/arm/ffitarget.h#L84
+    pub const FFI_GO_CLOSURES: u32 = 1;
+    pub const FFI_TRAMPOLINE_SIZE: usize = 12;
+    pub const FFI_NATIVE_RAW_API: u32 = 0;
+}
+
+#[cfg(target_arch = "arm")]
+pub use arm::*;
+
+/// From libffi:src/aarch64/ffitarget.h
+/// See: https://github.com/libffi/libffi/blob/c2a6859012d928b67a83619bd5087674a96b9254/src/aarch64/ffitarget.h#L44
+mod aarch64 {
+    use crate::ffi_abi;
+
+    pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+    pub const ffi_abi_FFI_SYSV: ffi_abi = 1;
+    pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 2;
+    pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_SYSV;
+
+    pub const FFI_NATIVE_RAW_API: u32 = 0;
+
+    #[cfg(target_vendor = "apple")]
+    pub const FFI_TRAMPOLINE_SIZE: usize = 16;
+
+    #[cfg(not(target_vendor = "apple"))]
+    pub const FFI_TRAMPOLINE_SIZE: usize = 24;
+
+    // No GO_CLOSURES on iOS or Windows
+    #[cfg(not(any(target_os = "windows", target_vendor = "apple")))]
+    pub const FFI_GO_CLOSURES: u32 = 1;
+}
+
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;
+
+/// From libffi:src/powerpc/ffitarget.h
+/// See: https://github.com/libffi/libffi/blob/73dd43afc8a447ba98ea02e9aad4c6898dc77fb0/src/powerpc/ffitarget.h#L60
+mod powerpc {
+    pub mod powerpc {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_SYSV_SOFT_FLOAT: ffi_abi = 0b000001;
+        pub const ffi_abi_FFI_SYSV_STRUCT_RET: ffi_abi = 0b000010;
+        pub const ffi_abi_FFI_SYSV_IBM_LONG_DOUBLE: ffi_abi = 0b000100;
+        pub const ffi_abi_FFI_SYSV: ffi_abi = 0b001000;
+        pub const ffi_abi_FFI_SYSV_LONG_DOUBLE_128: ffi_abi = 0b010000;
+
+        mod fprs {
+            pub const SOFT_FLOAT_FLAG: crate::ffi_abi = 0b0;
+        }
+
+        mod no_fprs {
+            pub const SOFT_FLOAT_FLAG: crate::ffi_abi = super::ffi_abi_FFI_SYSV_SOFT_FLOAT;
+        }
+
+        #[cfg(target_env = "gnuspe")]
+        use no_fprs::*;
+
+        #[cfg(not(target_feature = "gnuspe"))]
+        use fprs::*;
+
+        mod struct_ret {
+            pub const STRUCT_RET_FLAG: crate::ffi_abi = super::ffi_abi_FFI_SYSV_STRUCT_RET;
+        }
+
+        mod no_struct_ret {
+            pub const STRUCT_RET_FLAG: crate::ffi_abi = 0b0;
+        }
+
+        #[cfg(target_os = "netbsd")]
+        use struct_ret::*;
+
+        #[cfg(not(target_os = "netbsd"))]
+        use no_struct_ret::*;
+
+        mod long_double_64 {
+            pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi = 0b0;
+        }
+
+        mod long_double_128 {
+            pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi =
+                super::ffi_abi_FFI_SYSV_LONG_DOUBLE_128;
+        }
+
+        // IEEE128 is not supported on BSD or when targeting musl:
+        // https://github.com/rust-lang/llvm-project/blob/cb7f903994646c5b9223e0bb6cee3792190991f7/clang/lib/Basic/Targets/PPC.h#L379
+
+        #[cfg(any(target_os = "netbsd", target_os = "freebsd", target_env = "musl"))]
+        use long_double_64::*;
+
+        #[cfg(not(any(target_os = "netbsd", target_os = "freebsd", target_env = "musl")))]
+        use long_double_128::*;
+
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi =
+            ffi_abi_FFI_SYSV | SOFT_FLOAT_FLAG | STRUCT_RET_FLAG | LONG_DOUBLE_128_FLAG;
+
+        pub const FFI_NATIVE_RAW_API: u32 = 0;
+        pub const FFI_GO_CLOSURES: u32 = 1;
+    }
+
+    pub mod powerpc64 {
+        use crate::ffi_abi;
+
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_LINUX_STRUCT_ALIGN: ffi_abi = 0b000001;
+        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_128: ffi_abi = 0b000010;
+        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_IEEE128: ffi_abi = 0b000100;
+        pub const ffi_abi_FFI_LINUX: ffi_abi = 0b001000;
+
+        mod elfv1 {
+            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = 0b0;
+        }
+
+        mod elfv2 {
+            pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = super::ffi_abi_FFI_LINUX_STRUCT_ALIGN;
+            pub const FFI_TRAMPOLINE_SIZE: usize = 32;
+        }
+
+        // I think this should be something like `target_abi = "elf_v2"`, but that's not yet
+        // supported.
+        // Discussion: https://github.com/rust-lang/rust/issues/60617
+        // RFC: https://github.com/rust-lang/rfcs/pull/2992
+        //
+        // Instead, this is based on the current defaults at the time of this writing:
+        // https://github.com/rust-lang/rust/blob/50d2c3abd59af8cbed7e001b5b4e2f6a9a011112/src/librustc_target/abi/call/powerpc64.rs#L122
+
+        #[cfg(any(
+            // ELFv1 is the used for powerpc64 when not targeting musl
+            all(target_arch = "powerpc64", not(target_env = "musl")),
+            // Use empty flags when targeting a non-PowerPC target, too, just so code compiles.
+            not(target_arch = "powerpc64le")
+        ))]
+        use elfv1::*;
+
+        // ELFv2 is used for Little-Endian powerpc64 and with musl
+        #[cfg(any(
+            all(target_arch = "powerpc64", target_env = "musl"),
+            target_arch = "powerpc64le"
+        ))]
+        use elfv2::*;
+
+        mod long_double_64 {
+            pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi = 0b0;
+        }
+
+        mod long_double_128 {
+            pub const LONG_DOUBLE_128_FLAG: crate::ffi_abi =
+                super::ffi_abi_FFI_LINUX_LONG_DOUBLE_128;
+        }
+
+        // IEEE128 is not supported on BSD or when targeting musl:
+        // https://github.com/rust-lang/llvm-project/blob/cb7f903994646c5b9223e0bb6cee3792190991f7/clang/lib/Basic/Targets/PPC.h#L417
+
+        #[cfg(any(target_os = "netbsd", target_os = "freebsd", target_env = "musl"))]
+        use long_double_64::*;
+
+        #[cfg(not(any(target_os = "netbsd", target_os = "freebsd", target_env = "musl")))]
+        use long_double_128::*;
+
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi =
+            ffi_abi_FFI_LINUX | STRUCT_ALIGN_FLAG | LONG_DOUBLE_128_FLAG;
+
+        pub const FFI_NATIVE_RAW_API: u32 = 0;
+        pub const FFI_GO_CLOSURES: u32 = 1;
+
+        // If no elfv2...
+        #[cfg(all(target_arch = "powerpc64", not(target_env = "musl")))]
+        pub const FFI_TRAMPOLINE_SIZE: usize = 24;
+    }
+}
+
+#[cfg(target_arch = "powerpc")]
+pub use powerpc::powerpc::*;
+
+#[cfg(target_arch = "powerpc64")]
+pub use powerpc::powerpc64::*;

--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -209,9 +209,13 @@ mod powerpc {
         #[cfg(not(any(target_os = "netbsd", target_os = "freebsd", target_env = "musl")))]
         use long_double_128::*;
 
-        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi =
-            ffi_abi_FFI_SYSV | SOFT_FLOAT_FLAG | STRUCT_RET_FLAG | LONG_DOUBLE_128_FLAG;
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_SYSV
+            | ffi_abi_FFI_SYSV_IBM_LONG_DOUBLE
+            | SOFT_FLOAT_FLAG
+            | STRUCT_RET_FLAG
+            | LONG_DOUBLE_128_FLAG;
 
+        pub const FFI_TRAMPOLINE_SIZE: usize = 40;
         pub const FFI_NATIVE_RAW_API: u32 = 0;
         pub const FFI_GO_CLOSURES: u32 = 1;
     }

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -128,11 +128,7 @@ pub struct ffi_cif {
     pub vfp_nargs: c_ushort,
     #[cfg(all(target_arch = "arm"))]
     pub vfp_args: [c_schar; 16],
-    #[cfg(any(
-        target_arch = "powerpc",
-        target_arch = "powerpc64",
-        target_arch = "powerpc64le"
-    ))]
+    #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
     pub nfixedargs: c_uint,
 }
 

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -45,9 +45,13 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
+#![allow(unused_imports)]
 
 use std::mem::zeroed;
-use std::os::raw::{c_char, c_long, c_uint, c_ulong, c_ushort, c_void};
+use std::os::raw::{c_char, c_int, c_long, c_schar, c_uint, c_ulong, c_ushort, c_void};
+
+mod arch;
+pub use arch::*;
 
 pub type ffi_arg = c_ulong;
 pub type ffi_sarg = c_long;
@@ -57,36 +61,27 @@ pub type ffi_type_enum = u32;
 
 pub const FFI_64_BIT_MAX: u64 = 9223372036854775807;
 pub const FFI_CLOSURES: u32 = 1;
-pub const FFI_GO_CLOSURES: u32 = 1;
-pub const FFI_NATIVE_RAW_API: u32 = 0;
-pub const FFI_SIZEOF_ARG: u32 = 8;
-pub const FFI_SIZEOF_JAVA_RAW: u32 = 8;
-pub const FFI_TRAMPOLINE_SIZE: u32 = 24;
-pub const FFI_TYPE_COMPLEX: u32 = 15;
-pub const FFI_TYPE_DOUBLE: u32 = 3;
-pub const FFI_TYPE_FLOAT: u32 = 2;
-pub const FFI_TYPE_INT: u32 = 1;
-pub const FFI_TYPE_LAST: u32 = 15;
-pub const FFI_TYPE_LONGDOUBLE: u32 = 4;
-pub const FFI_TYPE_POINTER: u32 = 14;
-pub const FFI_TYPE_SINT16: u32 = 8;
-pub const FFI_TYPE_SINT32: u32 = 10;
-pub const FFI_TYPE_SINT64: u32 = 12;
-pub const FFI_TYPE_SINT8: u32 = 6;
-pub const FFI_TYPE_STRUCT: u32 = 13;
-pub const FFI_TYPE_UINT16: u32 = 7;
-pub const FFI_TYPE_UINT32: u32 = 9;
-pub const FFI_TYPE_UINT64: u32 = 11;
-pub const FFI_TYPE_UINT8: u32 = 5;
-pub const FFI_TYPE_VOID: u32 = 0;
+pub const FFI_SIZEOF_ARG: usize = std::mem::size_of::<c_long>();
+// NOTE: This only differs from FFI_SIZEOF_ARG on ILP platforms, which Rust does not support
+pub const FFI_SIZEOF_JAVA_RAW: usize = FFI_SIZEOF_ARG;
 
-pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 1;
-pub const ffi_abi_FFI_UNIX64: ffi_abi = 2;
-pub const ffi_abi_FFI_WIN64: ffi_abi = 3;
-pub const ffi_abi_FFI_EFI64: ffi_abi = 3;
-pub const ffi_abi_FFI_GNUW64: ffi_abi = 4;
-pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 5;
-pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = 2;
+pub const FFI_TYPE_VOID: u32 = 0;
+pub const FFI_TYPE_INT: u32 = 1;
+pub const FFI_TYPE_FLOAT: u32 = 2;
+pub const FFI_TYPE_DOUBLE: u32 = 3;
+pub const FFI_TYPE_LONGDOUBLE: u32 = 4;
+pub const FFI_TYPE_UINT8: u32 = 5;
+pub const FFI_TYPE_SINT8: u32 = 6;
+pub const FFI_TYPE_UINT16: u32 = 7;
+pub const FFI_TYPE_SINT16: u32 = 8;
+pub const FFI_TYPE_UINT32: u32 = 9;
+pub const FFI_TYPE_SINT32: u32 = 10;
+pub const FFI_TYPE_UINT64: u32 = 11;
+pub const FFI_TYPE_SINT64: u32 = 12;
+pub const FFI_TYPE_STRUCT: u32 = 13;
+pub const FFI_TYPE_POINTER: u32 = 14;
+pub const FFI_TYPE_COMPLEX: u32 = 15;
+pub const FFI_TYPE_LAST: u32 = 15;
 
 pub const ffi_status_FFI_OK: ffi_status = 0;
 pub const ffi_status_FFI_BAD_TYPEDEF: ffi_status = 1;
@@ -119,6 +114,24 @@ pub struct ffi_cif {
     pub rtype: *mut ffi_type,
     pub bytes: c_uint,
     pub flags: c_uint,
+    #[cfg(all(target_arch = "aarch64", target_os = "windows"))]
+    pub is_variadic: c_uint,
+    #[cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
+    pub aarch64_nfixedargs: c_uint,
+    #[cfg(all(target_arch = "arm"))]
+    pub vfp_used: c_int,
+    #[cfg(all(target_arch = "arm"))]
+    pub vfp_reg_free: c_ushort,
+    #[cfg(all(target_arch = "arm"))]
+    pub vfp_nargs: c_ushort,
+    #[cfg(all(target_arch = "arm"))]
+    pub vfp_args: [c_schar; 16],
+    #[cfg(any(
+        target_arch = "powerpc",
+        target_arch = "powerpc64",
+        target_arch = "powerpc64le"
+    ))]
+    pub nfixedargs: c_uint,
 }
 
 impl Default for ffi_cif {
@@ -133,7 +146,7 @@ pub union ffi_raw {
     pub sint: ffi_sarg,
     pub uint: ffi_arg,
     pub flt: f32,
-    pub data: [c_char; 8usize],
+    pub data: [c_char; FFI_SIZEOF_ARG],
     pub ptr: *mut c_void,
     _bindgen_union_align: u64,
 }
@@ -149,7 +162,7 @@ pub type ffi_java_raw = ffi_raw;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ffi_closure {
-    pub tramp: [c_char; 24usize],
+    pub tramp: [c_char; FFI_TRAMPOLINE_SIZE],
     pub cif: *mut ffi_cif,
     pub fun: Option<
         unsafe extern "C" fn(
@@ -171,8 +184,10 @@ impl Default for ffi_closure {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ffi_raw_closure {
-    pub tramp: [c_char; 24usize],
+    pub tramp: [c_char; FFI_TRAMPOLINE_SIZE],
     pub cif: *mut ffi_cif,
+    // See: https://github.com/libffi/libffi/blob/3a7580da73b7f16f275277316d00e3497cbb5a8c/include/ffi.h.in#L364
+    #[cfg(not(target_arch = "i686"))]
     pub translate_args: Option<
         unsafe extern "C" fn(
             arg1: *mut ffi_cif,
@@ -181,6 +196,7 @@ pub struct ffi_raw_closure {
             arg4: *mut c_void,
         ),
     >,
+    #[cfg(not(target_arch = "i686"))]
     pub this_closure: *mut c_void,
     pub fun: Option<
         unsafe extern "C" fn(
@@ -200,8 +216,10 @@ impl Default for ffi_raw_closure {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ffi_java_raw_closure {
-    pub tramp: [c_char; 24usize],
+    pub tramp: [c_char; FFI_TRAMPOLINE_SIZE],
     pub cif: *mut ffi_cif,
+    // See: https://github.com/libffi/libffi/blob/3a7580da73b7f16f275277316d00e3497cbb5a8c/include/ffi.h.in#L390
+    #[cfg(not(target_arch = "i686"))]
     pub translate_args: Option<
         unsafe extern "C" fn(
             arg1: *mut ffi_cif,
@@ -210,6 +228,7 @@ pub struct ffi_java_raw_closure {
             arg4: *mut c_void,
         ),
     >,
+    #[cfg(not(target_arch = "i686"))]
     pub this_closure: *mut c_void,
     pub fun: Option<
         unsafe extern "C" fn(
@@ -287,6 +306,8 @@ extern "C" {
 
     pub fn ffi_raw_size(cif: *mut ffi_cif) -> usize;
 
+    // See: https://github.com/libffi/libffi/blob/3a7580da73b7f16f275277316d00e3497cbb5a8c/include/ffi.h.in#L286
+    #[cfg(not(target_arch = "i686"))]
     pub fn ffi_java_raw_call(
         cif: *mut ffi_cif,
         fn_: Option<unsafe extern "C" fn()>,
@@ -370,6 +391,8 @@ extern "C" {
         codeloc: *mut c_void,
     ) -> ffi_status;
 
+    // See: https://github.com/libffi/libffi/blob/3a7580da73b7f16f275277316d00e3497cbb5a8c/include/ffi.h.in#L419
+    #[cfg(not(target_arch = "i686"))]
     pub fn ffi_prep_java_raw_closure(
         arg1: *mut ffi_java_raw_closure,
         cif: *mut ffi_cif,
@@ -384,6 +407,8 @@ extern "C" {
         user_data: *mut c_void,
     ) -> ffi_status;
 
+    // See: https://github.com/libffi/libffi/blob/3a7580da73b7f16f275277316d00e3497cbb5a8c/include/ffi.h.in#L419
+    #[cfg(not(target_arch = "i686"))]
     pub fn ffi_prep_java_raw_closure_loc(
         arg1: *mut ffi_java_raw_closure,
         cif: *mut ffi_cif,


### PR DESCRIPTION
This change attempts to make libffi-sys more portable to platforms other than `x86_64-unknown-linux-gnu` through a careful reading of libffi, Rust, and LLVM.

The constants which are redefined in this PR include:
- ffi_abi_*
- FFI_TRAMPOLINE_SIZE
- FFI_NATIVE_RAW_API
- FFI_GO_CLOSURES

This almost certainly isn't exhaustive - there are probably other divergences.

I've tested on:
- x86_64-pc-windows-msvc
- i686-pc-windows-msvc
- x86_64-unknown-linux-gnu (features=system)

I made the choice to avoid masking out large sections of code with `#[cfg]` to hopefully catch more issues at compile time. Instead, I try to only use `#[cfg]` to actually publish the host names.

Unfortunately, I don't have resources on-hand to test aarch64 or powerpc64. I wanted to check cross-compilation, but I couldn't get the code to build without features=system in my Ubuntu install. I think something about autoconf not being able to find `ld`? I'm not sure, the error message was difficult to understand.

**EDIT:** libffi-rs is now tested on:
* `x86_64-unknown-linux-gnu`
* `i686-unknown-linux-gnu`
* `aarch64-unknown-linux-gnu`
- `armv7-unknown-linux-gnueabihf`
* `powerpc64-unknown-linux-gnu`
* `powerpc64le-unknown-linux-gnu`

NOTE: `libffi-sys-rs` does not currently build for `powerpc-unknown-linux-gnu` with libffi 3.3, but it does build if you update libffi to the latest master branch. Unfortunately, the tests do not currently pass. Somebody else may have to figure out what the bug is.