### PR TITLE
fix soundness of `high` interface, around `ClosureN::code_ptr`

### DIFF
--- a/libffi-rs/examples/sort.rs
+++ b/libffi-rs/examples/sort.rs
@@ -3,9 +3,10 @@
 use libffi::high::Closure2;
 
 mod c {
+    use libffi::high::FnPtr2;
     use std::os::raw::{c_int, c_void};
 
-    pub type Callback = extern "C" fn(*const c_void, *const c_void) -> c_int;
+    pub type Callback<'a> = FnPtr2<'a, *const c_void, *const c_void, c_int>;
 
     extern "C" {
         pub fn qsort(base: *const c_void, nel: usize, width: usize, compar: Callback);

--- a/libffi-rs/src/lib.rs
+++ b/libffi-rs/src/lib.rs
@@ -78,7 +78,7 @@
 //! let closure = Closure2::new(&f);
 //! let fun     = closure.code_ptr();
 //!
-//! assert_eq!(18, fun(6, 7));
+//! assert_eq!(18, fun.call(6, 7));
 //! ```
 //!
 //! [the `libffi-sys` crate]: https://crates.io/crates/libffi-sys/


### PR DESCRIPTION
This attempts to fix issue #26 by adding the wrapper type discussed there.

Note that this is a breaking change to the API, and so would have to be accompanied by a major version increment.