### PR TITLE
Drop the make-cmd dependency

### DIFF
--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -20,6 +20,3 @@ features = ["system"]
 
 [target.'cfg(target_env = "msvc")'.build-dependencies]
 cc = "1.0.48"
-
-[target.'cfg(not(target_env = "msvc"))'.build-dependencies]
-make-cmd = "0.1"

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -1,4 +1,5 @@
 use crate::common::*;
+use std::process::Command;
 
 pub fn build_and_link() {
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -28,7 +29,7 @@ pub fn build_and_link() {
 
     run_command(
         "Building libffi",
-        make_cmd::make()
+        Command::new("make")
             .env_remove("DESTDIR")
             .arg("install")
             .current_dir(&build_dir),


### PR DESCRIPTION
This crate isn't useful, as we can just use "make" for all platforms. In
addition, this crate's `make()` function returns "gmake" on various BSD
platforms, which may not always work as per
https://github.com/tov/libffi-rs/issues/28.