### PR TITLE
Make FnPtrN: !Sync + !Send

### DIFF
--- a/libffi-rs/src/high/mod.rs
+++ b/libffi-rs/src/high/mod.rs
@@ -134,8 +134,10 @@ macro_rules! define_closure_mod {
             #[repr(transparent)]
             pub struct $fnptr<'a, $( $T, )* R> {
                 func: extern "C" fn($( $T, )*) -> R,
+                _marker: PhantomData<*const ()>,
                 _lifetime: PhantomData<&'a extern "C" fn($( $T, )*) -> R>,
             }
+
             impl<'a, $( $T, )* R> $fnptr<'a, $( $T, )* R> {
                 /// Call the wrapped [`fn`] pointer.
                 // We allow non snake case variable identifiers here because


### PR DESCRIPTION
This is intended to fix a soundness bug, the first item in #34, namely:

> It erases all auto trait information attached to closure captures (read: `Send` and `Sync`)

The simplest fix is to make <tt>FnPtr<i>N</i></tt> `!Send` and `!Sync`. This means we generally cannot pass our closures between threads, which may not be a satisfactory solution. An alternative PR I am working on will attempt to thread the auto traits from the original Rust closure through the <tt>Closure<i>…N</i></tt> to the <tt>FnPtr<i>N</i></tt>.