### PR TITLE
Make additional types Send + Sync

### DIFF
--- a/libffi-rs/src/high/types.rs
+++ b/libffi-rs/src/high/types.rs
@@ -12,7 +12,7 @@ use super::super::middle;
 #[derive(Clone, Debug)]
 pub struct Type<T> {
     untyped: middle::Type,
-    _marker: PhantomData<*mut T>,
+    _marker: PhantomData<fn() -> T>,
 }
 
 impl<T> Type<T> {

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -82,6 +82,9 @@ pub struct Cif {
     result: Type,
 }
 
+unsafe impl Send for Cif {}
+unsafe impl Sync for Cif {}
+
 // To clone a Cif we need to clone the types and then make sure the new
 // ffi_cif refers to the clones of the types.
 impl Clone for Cif {

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -52,11 +52,17 @@ type Owned<T> = T;
 /// ```
 pub struct Type(Unique<low::ffi_type>);
 
+unsafe impl Send for Type {}
+unsafe impl Sync for Type {}
+
 /// Represents a sequence of C types.
 ///
 /// This can be used to construct a struct type or as the arguments
 /// when creating a [`Cif`].
 pub struct TypeArray(Unique<*mut low::ffi_type>);
+
+unsafe impl Send for TypeArray {}
+unsafe impl Sync for TypeArray {}
 
 impl fmt::Debug for Type {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
 Make some types Send + Sync:

  - middle::Cif
  - middle::Type
  - high::Type<T>

I believe this is safe because none of these types
provides any kind of interior mutability. The wrappers
ensure that these types behave like ordinary, owned
Rust objects.