### PR TITLE
fix(aarch64): linker error with C long double

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -136,7 +136,7 @@ pub mod types {
         ffi_type_uint64 as uint64, ffi_type_uint8 as uint8, ffi_type_void as void,
     };
 
-    #[cfg(not(all(target_arch = "arm")))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub use crate::raw::ffi_type_longdouble as longdouble;
 
     #[cfg(feature = "complex")]

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -369,7 +369,7 @@ impl Type {
     }
 
     /// Returns the C `long double` (extended-precision floating point) type.
-    #[cfg(not(all(target_arch = "arm")))]
+    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn longdouble() -> Self {
         Type(unsafe { Unique::new(&mut low::types::longdouble) })
     }

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -341,6 +341,7 @@ extern "C" {
     pub static mut ffi_type_double: ffi_type;
     pub static mut ffi_type_pointer: ffi_type;
 
+    #[cfg(not(target_arch = "aarch64"))]
     #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
     pub static mut ffi_type_longdouble: ffi_type;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34997667/152466676-e43d3b03-be5b-46db-b179-769413ddc009.png)

I was building `deno` with `-rdynamic` and I got this undefined symbol linker error on `aarch64-apple-darwin`. Applying this patch fixed it for me.