### PR TITLE
Better cross compilation support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [i686-pc-windows-msvc, x86_64-pc-windows-msvc]
-        channel: [1.36.0, stable, beta, nightly]
+        channel: [1.48.0, stable, beta, nightly]
     runs-on: windows-latest
     name: Windows - ${{ matrix.target }} - ${{ matrix.channel }}
     env:
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.36.0, stable, beta, nightly]
+        channel: [1.48.0, stable, beta, nightly]
     runs-on: windows-latest
     name: Windows - x86_64-pc-windows-gnu - ${{ matrix.channel }}
     env:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.36.0, stable, beta, nightly]
+        channel: [1.48.0, stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
     runs-on: macos-latest
     name: macOS - ${{ matrix.channel }} ${{ matrix.features }}
@@ -126,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.36.0, stable, beta, nightly]
+        channel: [1.48.0, stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
         target:
         - x86_64-unknown-linux-gnu
@@ -147,9 +147,9 @@ jobs:
           features: "--features system"
         - target: riscv64gc-unknown-linux-gnu
           features: "--features system"
-        # 1.36.0 is too old for riscv64gc-unknown-linux-gnu
+        # 1.48.0 is too old for riscv64gc-unknown-linux-gnu
         - target: riscv64gc-unknown-linux-gnu
-          channel: 1.36.0
+          channel: 1.48.0
 
     runs-on: ubuntu-latest
     name: Linux - ${{ matrix.channel }} ${{ matrix.features }} ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,22 @@ name: Build & Test
 on: [push, pull_request]
 
 jobs:
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
   windows-msvc:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ libffi = { version = "2.0.0", features = ["system"] }
 See [the `libffi-sys` documentation] for more information about how it
 finds C libffi.
 
-This crate supports Rust version 1.36 and later.
+This crate supports Rust version 1.48 and later.
 
 ### Examples
 

--- a/libffi-rs/README.md
+++ b/libffi-rs/README.md
@@ -40,7 +40,7 @@ libffi = { version = "2.0.1", features = ["system"] }
 See [the `libffi-sys` documentation] for more information about how it
 finds C libffi.
 
-This crate supports Rust version 1.36 and later.
+This crate supports Rust version 1.48 and later.
 
 ### Examples
 

--- a/libffi-rs/src/lib.rs
+++ b/libffi-rs/src/lib.rs
@@ -38,7 +38,7 @@
 //! See [the `libffi-sys` documentation] for more information about how it
 //! finds C libffi.
 //!
-//! This crate supports Rust version 1.36 and later.
+//! This crate supports Rust version 1.48 and later.
 //!
 //! # Organization
 //!

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -18,5 +18,5 @@ complex = []
 [package.metadata.docs.rs]
 features = ["system"]
 
-[target.'cfg(target_env = "msvc")'.build-dependencies]
-cc = "1.0.48"
+[build-dependencies]
+cc = "1.0"

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -49,6 +49,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
     command
         .arg("configure")
         .arg("--with-pic")
+        .arg("--disable-shared")
         .arg("--disable-docs");
 
     let target = std::env::var("TARGET").unwrap();

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -52,13 +52,38 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
         .arg("--disable-docs");
 
     let target = std::env::var("TARGET").unwrap();
-    if target != std::env::var("HOST").unwrap() {
+    let host = std::env::var("HOST").unwrap();
+    if target != host {
         // Autoconf uses riscv64 while Rust uses riscv64gc for the architecture
         if target == "riscv64gc-unknown-linux-gnu" {
             command.arg("--host=riscv64-unknown-linux-gnu");
         } else {
             command.arg(format!("--host={}", target));
         }
+    }
+
+    let mut c_cfg = cc::Build::new();
+    c_cfg
+        .cargo_metadata(false)
+        .target(&target)
+        .warnings(false)
+        .host(&host);
+    let c_compiler = c_cfg.get_compiler();
+
+    command.env("CC", c_compiler.path());
+
+    let mut cflags = c_compiler.cflags_env();
+    match env::var_os("CFLAGS") {
+        None => (),
+        Some(flags) => {
+            cflags.push(" ");
+            cflags.push(&flags);
+        }
+    }
+    command.env("CFLAGS", cflags);
+
+    for (k, v) in c_compiler.env().iter() {
+        command.env(k, v);
     }
 
     command.current_dir(&build_dir);


### PR DESCRIPTION
Originally I want to use [autotools-rs](https://github.com/lu-zero/autotools-rs), but it doesn't support Rust 1.36.0.

This enables building with [cargo-zigbuild](https://github.com/messense/cargo-zigbuild):

```bash
cargo zigbuild --target x86_64-unknown-linux-gnu
```