### PR TITLE
avoid abort_on_panic dependency

### DIFF
--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 libffi-sys = { path = "../libffi-sys-rs", version = "^2.0"}
-abort_on_panic = "2.0.0"
 libc = "0.2.65"
 
 [features]

--- a/libffi-rs/src/high/mod.rs
+++ b/libffi-rs/src/high/mod.rs
@@ -68,8 +68,6 @@
 //!
 //! Invoking the closure a second time will panic.
 
-use abort_on_panic::abort_on_panic;
-
 pub use crate::middle::{ffi_abi_FFI_DEFAULT_ABI, FfiAbi};
 
 pub mod types;
@@ -77,6 +75,17 @@ pub use types::{CType, Type};
 
 pub mod call;
 pub use call::*;
+
+macro_rules! abort_on_panic {
+    ($msg:literal, $body:expr) => {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { $body }))
+            .unwrap_or_else(|err| {
+                std::mem::forget(err); // defends against the issue that dropping `err` might panic
+                eprintln!($msg);
+                std::process::abort()
+            })
+    }
+}
 
 macro_rules! define_closure_mod {
     (


### PR DESCRIPTION
This can be implemented trivially in a 10-line macro, so it does not seem worth the dependency.

abort_on_panic is licensed under CC0 which is [falling out of favor](https://lwn.net/Articles/902410/) and which might [be a problem](https://rust-lang.zulipchat.com/#narrow/stream/231349-t-core.2Flicensing/topic/CC0.20license.3F) for having Miri depend on libffi-rs.

(I have implemented this from scratch without looking at the abort_on_panic code.)