### PR TITLE
Fix cross-compiling to illumos

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -55,12 +55,15 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
     let target = std::env::var("TARGET").unwrap();
     let host = std::env::var("HOST").unwrap();
     if target != host {
-        // Autoconf uses riscv64 while Rust uses riscv64gc for the architecture
-        if target == "riscv64gc-unknown-linux-gnu" {
-            command.arg("--host=riscv64-unknown-linux-gnu");
-        } else {
-            command.arg(format!("--host={}", target));
-        }
+        let cross_host = match target.as_str() {
+            // Autoconf uses riscv64 while Rust uses riscv64gc for the architecture
+            "riscv64gc-unknown-linux-gnu" => "riscv64-unknown-linux-gnu",
+            // Autoconf does not yet recognize illumos, but Solaris should be fine
+            "x86_64-unknown-illumos" => "x86_64-unknown-solaris",
+            // Everything else should be fine to pass straight through
+            other => other,
+        };
+        command.arg(format!("--host={}", cross_host));
     }
 
     let mut c_cfg = cc::Build::new();


### PR DESCRIPTION
When cross-compiling for an illumos target, the rust host triple is not yet recognized by autoconf and friends.  Falling back to a Solaris one which will be adequate for compatibility purposes.