### PR TITLE
fix: Copy size and alignment of structures on clone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.48.0, stable, beta, nightly]
+        # rust < 1.54 does not work on macos >= 12:
+        # https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20How.20can.20I.20fix.20Rust.201.2E53.2E0.20or.20earlier.20to.20run.20on.20macOS.2012.2E6.3F/near/299263887
+        # channel: [1.48.0, stable, beta, nightly]
+        channel: [stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
     runs-on: macos-latest
     name: macOS - ${{ matrix.channel }} ${{ matrix.features }}
@@ -200,13 +203,13 @@ jobs:
           # Install cross-compiler
           sudo apt-get update
           sudo apt-get install -y \
-            gcc-8-$(echo $GCC_ARCH | tr _ -)-linux-$ABI
+            gcc-9-$(echo $GCC_ARCH | tr _ -)-linux-$ABI
 
           # Convert target triple to uppercase and replace - with _
           TARGET_TRIPLE=$(echo "${{ matrix.target }}" | tr - _)
           TARGET_TRIPLE=${TARGET_TRIPLE^^}
 
-          CC=$GCC_ARCH-linux-$ABI-gcc-8
+          CC=$GCC_ARCH-linux-$ABI-gcc-9
 
           # Set cross-compiler as CC and set cargo target runner as qemu
           echo "CC=$CC" >> $GITHUB_ENV

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -489,4 +489,59 @@ mod test {
 
         *result = userdata(arg1, arg2);
     }
+
+    #[test]
+    fn clone_cif() {
+        let cif = Cif::new(
+            vec![
+                Type::structure(vec![
+                    Type::structure(vec![Type::u64(), Type::u8(), Type::f64()]),
+                    Type::i8(),
+                    Type::i64(),
+                ]),
+                Type::u64(),
+            ]
+            .into_iter(),
+            Type::u64(),
+        );
+        let clone_cif = cif.clone();
+
+        unsafe {
+            let args = std::slice::from_raw_parts(cif.cif.arg_types, cif.cif.nargs as usize);
+            let struct_arg = args
+                .first()
+                .expect("CIF arguments slice was empty")
+                .as_ref()
+                .expect("CIF first argument was null");
+            // Get slice of length 1 to get the first element
+            let struct_size = struct_arg.size;
+            let struct_parts = std::slice::from_raw_parts(struct_arg.elements, 1);
+            let substruct_size = struct_parts
+                .first()
+                .expect("CIF struct argument's elements slice was empty")
+                .as_ref()
+                .expect("CIF struct argument's first element was null")
+                .size;
+
+            let clone_args =
+                std::slice::from_raw_parts(clone_cif.cif.arg_types, clone_cif.cif.nargs as usize);
+            let clone_struct_arg = clone_args
+                .first()
+                .expect("CIF arguments slice was empty")
+                .as_ref()
+                .expect("CIF first argument was null");
+            // Get slice of length 1 to get the first element
+            let clone_struct_size = clone_struct_arg.size;
+            let clone_struct_parts = std::slice::from_raw_parts(clone_struct_arg.elements, 1);
+            let clone_substruct_size = clone_struct_parts
+                .first()
+                .expect("Cloned CIF struct argument's elements slice was empty")
+                .as_ref()
+                .expect("Cloned CIF struct argument's first element was null")
+                .size;
+
+            assert_eq!(struct_size, clone_struct_size);
+            assert_eq!(substruct_size, clone_substruct_size);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixed a bug where cloning a `Cif` containing a structure would not copy over the size and alignment of the structure into the cloned `Cif`. A test is added to guard against regression.

The code has been `cargo fmt`'d but has not been linted with eg. clippy, if such a tool is in use in the project.