### PR TITLE
Support aarch64-apple-ios-sim

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -60,6 +60,9 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
             "riscv64gc-unknown-linux-gnu" => "riscv64-unknown-linux-gnu",
             // Autoconf does not yet recognize illumos, but Solaris should be fine
             "x86_64-unknown-illumos" => "x86_64-unknown-solaris",
+            // configure.host does not extract `ios-sim` as OS.
+            // The sources for `ios-sim` should be the same as `ios`.
+            "aarch64-apple-ios-sim" => "aarch64-apple-ios",
             // Everything else should be fine to pass straight through
             other => other,
         };


### PR DESCRIPTION
To reproduce:
```
cargo build --package libffi-sys --target aarch64-apple-ios-sim -vvvv
```
fails with:
```
[libffi-sys 2.1.0] "sh" "configure" "--with-pic" "--disable-shared" "--disable-docs" "--host=aarch64-apple-ios-sim" "--prefix" "/Users/user/libffi-rs/target/aarch64-apple-ios-sim/debug/build/libffi-sys-8b0f215606b4c280/out/libffi-root"
[libffi-sys 2.1.0] checking build system type... aarch64-apple-darwin22.1.0
[libffi-sys 2.1.0] Invalid configuration `aarch64-apple-ios-sim': Kernel `ios' not known to work with OS `sim'.
[libffi-sys 2.1.0] configure: error: /bin/sh ./config.sub aarch64-apple-ios-sim failed
[libffi-sys 2.1.0] thread 'main' panicked at 'Configuring libffi', libffi-sys-rs/build/common.rs:8:5
```