### PR TITLE
Support aarch64 msvc target

### DIFF
--- a/libffi-sys-rs/build/msvc.rs
+++ b/libffi-sys-rs/build/msvc.rs
@@ -1,6 +1,11 @@
 use crate::common::*;
 
-const INCLUDE_DIRS: &[&str] = &["libffi", "libffi/include", "include/msvc", "libffi/src/x86"];
+const INCLUDE_DIRS: &[&str] = &["libffi", "libffi/include", "include/msvc"];
+
+// libffi expects us to include the same folder in case of x86 and x86_64 architectures
+const INCLUDE_DIRS_X86: &[&str] = &["libffi/src/x86"];
+const INCLUDE_DIRS_X86_64: &[&str] = &["libffi/src/x86"];
+const INCLUDE_DIRS_AARCH64: &[&str] = &["libffi/src/aarch64"];
 
 const BUILD_FILES: &[&str] = &[
     "tramp.c",
@@ -8,33 +13,55 @@ const BUILD_FILES: &[&str] = &[
     "prep_cif.c",
     "raw_api.c",
     "types.c",
-    "x86/ffi.c",
 ];
-
-const BUILD_FILES_X64: &[&str] = &["x86/ffiw64.c"];
+const BUILD_FILES_X86: &[&str] = &["x86/ffi.c"];
+const BUILD_FILES_X86_64: &[&str] = &["x86/ffi.c", "x86/ffiw64.c"];
+const BUILD_FILES_AARCH64: &[&str] = &["aarch64/ffi.c"];
 
 fn add_file(build: &mut cc::Build, file: &str) {
     build.file(format!("libffi/src/{}", file));
 }
 
+fn unsupported(arch: &str) -> ! {
+    panic!("Unsupported architecture: {}", arch)
+}
+
 pub fn build_and_link() {
     let target = env::var("TARGET").unwrap();
-    let is_x64 = target.contains("x86_64");
-    let asm_path = pre_process_asm(INCLUDE_DIRS, &target, is_x64);
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
+    // we should collect all include dirs together with platform specific ones
+    // to pass them over to the asm pre-processing step
+    let mut all_includes = vec![];
+    for each_include in INCLUDE_DIRS {
+        all_includes.push(*each_include);
+    }
+    for each_include in match target_arch.as_str() {
+        "x86" => INCLUDE_DIRS_X86,
+        "x86_64" => INCLUDE_DIRS_X86_64,
+        "aarch64" => INCLUDE_DIRS_AARCH64,
+        _ => unsupported(&target_arch),
+    } {
+        all_includes.push(*each_include);
+    }
+
+    let asm_path = pre_process_asm(all_includes.as_slice(), &target, &target_arch);
     let mut build = cc::Build::new();
 
-    for inc in INCLUDE_DIRS {
-        build.include(inc);
+    for each_include in all_includes {
+        build.include(each_include);
     }
 
-    for file in BUILD_FILES {
-        add_file(&mut build, file);
+    for each_source in BUILD_FILES {
+        add_file(&mut build, each_source);
     }
-
-    if is_x64 {
-        for file in BUILD_FILES_X64 {
-            add_file(&mut build, file);
-        }
+    for each_source in match target_arch.as_str() {
+        "x86" => BUILD_FILES_X86,
+        "x86_64" => BUILD_FILES_X86_64,
+        "aarch64" => BUILD_FILES_AARCH64,
+        _ => unsupported(&target_arch),
+    } {
+        add_file(&mut build, each_source);
     }
 
     build
@@ -54,16 +81,38 @@ pub fn probe_and_link() {
     build_and_link();
 }
 
-pub fn pre_process_asm(include_dirs: &[&str], target: &str, is_x64: bool) -> String {
-    let file_name = if is_x64 { "win64_intel" } else { "sysv_intel" };
+pub fn pre_process_asm(include_dirs: &[&str], target: &str, target_arch: &str) -> String {
+    let folder_name = match target_arch {
+        "x86" => "x86",
+        "x86_64" => "x86",
+        "aarch64" => "aarch64",
+        _ => unsupported(target_arch),
+    };
 
-    let mut cmd = cc::windows_registry::find(&target, "cl.exe").expect("Could not locate cl.exe");
-    cmd.env("INCLUDE", include_dirs.join(";"));
+    let file_name = match target_arch {
+        "x86" => "sysv_intel",
+        "x86_64" => "win64_intel",
+        "aarch64" => "win64_armasm",
+        _ => unsupported(target_arch),
+    };
+
+    let mut cmd = cc::windows_registry::find(target, "cl.exe").expect("Could not locate cl.exe");
+
+    // When cross-compiling we should provide MSVC includes as part of the INCLUDE env.var
+    let build = cc::Build::new();
+    for (key, value) in build.get_compiler().env() {
+        if key.to_string_lossy() == "INCLUDE" {
+            cmd.env(
+                "INCLUDE",
+                format!("{};{}", value.to_string_lossy(), include_dirs.join(";")),
+            );
+        }
+    }
 
     cmd.arg("/EP");
-    cmd.arg(format!("libffi/src/x86/{}.S", file_name));
+    cmd.arg(format!("libffi/src/{}/{}.S", folder_name, file_name));
 
-    let out_path = format!("libffi/src/x86/{}.asm", file_name);
+    let out_path = format!("libffi/src/{}/{}.asm", folder_name, file_name);
     let asm_file = fs::File::create(&out_path).expect("Could not create output file");
 
     cmd.stdout(asm_file);


### PR DESCRIPTION
Hi @tov 

I noticed that it is not possible to compile `libffi` for aarch64 msvc target:
```
cargo build --target aarch64-pc-windows-msvc -vvvv
```

This PR refactors `msvc.rs` to slightly generalise the build process of msvc targets.
In addition, it adds support for cross-compilation by passing `INCLUDE` env.var constructed by `cc::Build` to the `cl.exe` in the asm pre-processing step, otherwise it would not be able to find appropriate headers for the target architecture.