### PR TITLE
Fix return type in call example code

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -330,7 +330,7 @@ pub unsafe fn prep_cif_var(
 ///     prep_cif(&mut cif, ffi_abi_FFI_DEFAULT_ABI, 2,
 ///              &mut types::uint64, args.as_mut_ptr()).unwrap();
 ///
-///     call(&mut cif, CodePtr(c_function as *mut _),
+///     call::<u64>(&mut cif, CodePtr(c_function as *mut _),
 ///          vec![ &mut 4u64 as *mut _ as *mut c_void,
 ///                &mut 5u64 as *mut _ as *mut c_void ].as_mut_ptr())
 /// };


### PR DESCRIPTION
In the example code provided as part of the documention of `call`, the return type is not explicitly specified, and will be inferred by the Rust compiler as `i32`.  However, the actual C routine being invoked has a `u64` return type.  This can cause the test to fail on big-endian platforms.

Fixed by explicitly specifying the `u64` return type.