### PR TITLE
Handle return type promotion in the high layer

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -120,7 +120,9 @@ impl CodePtr {
     }
 }
 
-pub use raw::{ffi_abi, ffi_abi_FFI_DEFAULT_ABI, ffi_cif, ffi_closure, ffi_status, ffi_type};
+pub use raw::{
+    ffi_abi, ffi_abi_FFI_DEFAULT_ABI, ffi_arg, ffi_cif, ffi_closure, ffi_sarg, ffi_status, ffi_type,
+};
 
 /// Re-exports the [`ffi_type`] objects used to describe the types of
 /// arguments and results.


### PR DESCRIPTION
As described in https://github.com/tov/libffi-rs/issues/66, the libffi library implicitly extends small integer types used as return types, both in calls and closure callbacks.  This is not currently addressed by the existing code base.

For the low and middle layers, the user can manually address this issue by using appropriate return types.  However, for the high layer, the types are automatically determined, and are currently incorrect.  This leads to problems (primarily) on big-endian platforms.

This PR addresses the return type extension in the high layer by storing the extended type used by libffi as an associated type `RetType` in the `CType` trait, and using that type when performing calls or constructing closure callbacks.

This implementation does not change the libffi-rs API, and should not add any significant run-time overhead.