### PR TITLE
Work around clang-16 build failure

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -74,6 +74,9 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
         .cargo_metadata(false)
         .target(&target)
         .warnings(false)
+        // Work around a build failure with clang-16 and newer.  Can be removed
+        // once https://github.com/libffi/libffi/pull/764 is merged.
+        .flag_if_supported("-Wno-implicit-function-declaration")
         .host(&host);
     let c_compiler = c_cfg.get_compiler();
 


### PR DESCRIPTION
Building with clang-16 or newer currently fails as the issue described in https://github.com/libffi/libffi/issues/760 causes a compile error.

Fix this by adding the -Wno-implicit-function-declaration compiler flag, which allows the current source code to still be built.

Addresses https://github.com/tov/libffi-rs/issues/73.