### PR TITLE
Run the configure script that's in the current directory, not on the PATH

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -47,7 +47,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
     let mut command = Command::new("sh");
 
     command
-        .arg("configure")
+        .arg("./configure")
         .arg("--with-pic")
         .arg("--disable-shared")
         .arg("--disable-docs");


### PR DESCRIPTION
`configure_libffi` should run `./configure`, not unqualified `configure`. This was causing an extremely confusing error because I happened to have an unrelated executable named `configure` in my PATH.