### PR TITLE
libffi-sys: arch: add constants for the MIPS family

### DIFF
--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -363,3 +363,49 @@ mod loongarch64 {
 
 #[cfg(target_arch = "loongarch64")]
 pub use loongarch64::*;
+
+/// From libffi:src/mips/ffitarget.h
+/// See: <https://github.com/libffi/libffi/blob/4cb776bc8075332d2f3e59f51785d621fcda48f6/src/mips/ffitarget.h>
+mod mips {
+    mod common {
+        use crate::ffi_abi;
+        pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
+        pub const ffi_abi_FFI_O32: ffi_abi = 1;
+        pub const ffi_abi_FFI_N32: ffi_abi = 2;
+        pub const ffi_abi_FFI_N64: ffi_abi = 3;
+        pub const ffi_abi_FFI_O32_SOFT_FLOAT: ffi_abi = 4;
+        pub const ffi_abi_FFI_N32_SOFT_FLOAT: ffi_abi = 5;
+        pub const ffi_abi_FFI_N64_SOFT_FLOAT: ffi_abi = 6;
+        pub const ffi_abi_FFI_LAST_ABI: ffi_abi = 7;
+
+        pub const FFI_CLOSURES: u32 = 1;
+        pub const FFI_GO_CLOSURES: u32 = 1;
+        pub const FFI_NATIVE_RAW_ABI: u32 = 0;
+    }
+
+    pub mod mips {
+        use crate::ffi_abi;
+
+        pub use super::common::*;
+
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_O32;
+
+        pub const FFI_TRAMPOLINE_SIZE: usize = 20;
+    }
+
+    pub mod mips64 {
+        use crate::ffi_abi;
+
+        pub use super::common::*;
+
+        pub const ffi_abi_FFI_DEFAULT_ABI: ffi_abi = ffi_abi_FFI_N64;
+
+        pub const FFI_TRAMPOLINE_SIZE: usize = 56;
+    }
+}
+
+#[cfg(any(target_arch = "mips", target_arch = "mips32r6"))]
+pub use mips::mips::*;
+
+#[cfg(any(target_arch = "mips64", target_arch = "mips64r6"))]
+pub use mips::mips64::*;

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -137,6 +137,13 @@ pub struct ffi_cif {
     pub loongarch_nfixedargs: c_uint,
     #[cfg(all(target_arch = "loongarch64"))]
     pub loongarch_unused: c_uint,
+    #[cfg(any(
+        target_arch = "mips",
+        target_arch = "mips32r6",
+        target_arch = "mips64",
+        target_arch = "mips64r6"
+    ))]
+    pub mips_nfixedargs: c_uint,
 }
 
 impl Default for ffi_cif {


### PR DESCRIPTION
Fixes #67.