### PR TITLE
Made `high::Type::make` public so `CType` can be implemented

### DIFF
--- a/libffi-rs/src/high/types.rs
+++ b/libffi-rs/src/high/types.rs
@@ -17,7 +17,8 @@ pub struct Type<T> {
 }
 
 impl<T> Type<T> {
-    fn make(untyped: middle::Type) -> Self {
+    /// Make a high type from a middle type.
+    pub fn make(untyped: middle::Type) -> Self {
         Type {
             untyped,
             _marker: PhantomData,


### PR DESCRIPTION
This is to provide a solution for https://github.com/tov/libffi-rs/issues/48

In projects that uses `bindgen`, it would generate structs such as 

```rs
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct trade_event {
    pub size: u64,
    pub price: u64,
    pub side: side,
}
```

and if one has a function pointer such as 

```rs
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct event_handler {
    pub handle_trade_event: ::std::option::Option<unsafe extern "C" fn(event: trade_event)>,
}
```

Then, at the moment it won't work because `trade_event` doesn't implement `CType`. Although `CType` is public but `high::Type::make` is not hence it is not possible to implement `CType` outside of the crate.

After this change, users are able to implement `CType` on their own. For example,

```rs
unsafe impl CType for trade_event {
    fn reify() -> libffi::high::Type<Self> {
        libffi::high::Type::make(libffi::middle::Type::structure([
            libffi::middle::Type::u64(),    // size
            libffi::middle::Type::u64(),    // price
            libffi::middle::Type::c_uint(), // side
        ]))
    }

    type RetType = trade_event;
}
```

Now that `trade_event` implements `CType`, it is possible to construct the function pointer as shown above for `event_handler`.