### PR TITLE
Pretty display for build errors

### DIFF
--- a/libffi-sys-rs/build/common.rs
+++ b/libffi-sys-rs/build/common.rs
@@ -4,6 +4,17 @@ pub use std::{
     process::Command,
 };
 
+#[track_caller]
 pub fn run_command(which: &'static str, cmd: &mut Command) {
-    assert!(cmd.status().expect(which).success(), "{}", which);
+    match cmd.status() {
+        Ok(status) if status.success() => return,
+        Ok(status) => {
+            println!("cargo:warning={} failed with {}", which, status);
+            panic!("{}: {} ({:?})", which, status, cmd);
+        }
+        Err(err) => {
+            println!("cargo:warning={} failed with error {}", which, err);
+            panic!("{}: {} ({:?})", which, err, cmd);
+        },
+    }
 }


### PR DESCRIPTION
The assert is not very informative. This makes the error point to more relevant code line, and print a nicer error in Cargo.