### PR TITLE
Fix build for powerpc64-unknown-linux-musl

### DIFF
--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -251,7 +251,7 @@ mod powerpc {
             // ELFv1 is the used for powerpc64 when not targeting musl
             all(target_arch = "powerpc64", target_endian="big", not(target_env = "musl")),
             // Use empty flags when targeting a non-PowerPC target, too, just so code compiles.
-            not(all(target_arch = "powerpc64", target_endian="little"))
+            not(target_arch = "powerpc64")
         ))]
         mod elf {
             pub use super::elfv1::*;


### PR DESCRIPTION
Currently, `powerpc64-unknown-linux-musl` matches both `not(all(target_arch = "powerpc64", target_endian="little"))` and `all(target_arch = "powerpc64", target_endian = "big", target_env = "musl")`, causing a duplicate definition of the `elf` module. `powerpc64-unknown-linux-musl` should use ELF v2, so fix the conditional logic to make it use only that.