### PR TITLE
[AIX] Use GNU Make to build

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -132,5 +132,9 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
         command.arg("--prefix").arg(prefix);
     }
 
+    if cfg!(target_os = "aix") {
+        command.arg("--disable-multi-os-directory");
+    }
+
     run_command("Configuring libffi", &mut command);
 }

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -37,9 +37,14 @@ pub fn build_and_link() {
     // Generate configure, run configure, make, make install
     configure_libffi(prefix, &build_dir);
 
+    let make_command = if cfg!(target_os = "aix") {
+        "gmake"
+    } else {
+        "make"
+    };
     run_command(
         "Building libffi",
-        Command::new("make")
+        Command::new(make_command)
             .env_remove("DESTDIR")
             .arg("install")
             .current_dir(&build_dir),

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -134,6 +134,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
 
     if cfg!(target_os = "aix") {
         command.arg("--disable-multi-os-directory");
+        command.arg("--disable-dependency-tracking");
     }
 
     run_command("Configuring libffi", &mut command);

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -138,8 +138,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
     }
 
     if cfg!(target_os = "aix") {
-        command.arg("--disable-multi-os-directory");
-        command.arg("--disable-dependency-tracking");
+        command.env("MAKE", "gmake");
     }
 
     run_command("Configuring libffi", &mut command);


### PR DESCRIPTION
This PR explicitly sets `gmake` as the make to use when running on AIX, as libffi's autoconf based configure and resulting Makefile depend on GNU Make to work successfully (and AIX's default make is UNIX make, not GNU).