### PR TITLE
Bump MSRV to 1.78.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         toolchain: [i686-pc-windows-msvc, x86_64-pc-windows-msvc]
         target: [i686-pc-windows-msvc, x86_64-pc-windows-msvc, aarch64-pc-windows-msvc]
-        channel: [1.48.0, stable, beta, nightly]
+        channel: [1.78.0, stable, beta, nightly]
     runs-on: windows-latest
     name: Windows - ${{ matrix.target }} - ${{ matrix.channel }}
     env:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.48.0, stable, beta, nightly]
+        channel: [1.78.0, stable, beta, nightly]
     runs-on: windows-latest
     name: Windows - x86_64-pc-windows-gnu - ${{ matrix.channel }}
     env:
@@ -95,7 +95,7 @@ jobs:
       matrix:
         # rust < 1.54 does not work on macos >= 12:
         # https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20How.20can.20I.20fix.20Rust.201.2E53.2E0.20or.20earlier.20to.20run.20on.20macOS.2012.2E6.3F/near/299263887
-        # channel: [1.48.0, stable, beta, nightly]
+        # channel: [1.78.0, stable, beta, nightly]
         channel: [stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
     runs-on: macos-latest
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        channel: [1.48.0, stable, beta, nightly]
+        channel: [1.78.0, stable, beta, nightly]
         features: ["--no-default-features", "--features system"]
         target:
         - x86_64-unknown-linux-gnu
@@ -154,9 +154,9 @@ jobs:
           features: "--features system"
         - target: s390x-unknown-linux-gnu
           features: "--features system"
-        # 1.48.0 is too old for riscv64gc-unknown-linux-gnu
+        # 1.78.0 is too old for riscv64gc-unknown-linux-gnu
         - target: riscv64gc-unknown-linux-gnu
-          channel: 1.48.0
+          channel: 1.78.0
 
     runs-on: ubuntu-latest
     name: Linux - ${{ matrix.channel }} ${{ matrix.features }} ${{ matrix.target }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ libffi = { version = "2.0.0", features = ["system"] }
 See [the `libffi-sys` documentation] for more information about how it
 finds C libffi.
 
-This crate supports Rust version 1.48 and later.
+This crate supports Rust version 1.78 and later.
 
 ### Examples
 

--- a/libffi-rs/README.md
+++ b/libffi-rs/README.md
@@ -40,7 +40,7 @@ libffi = { version = "3.2.0", features = ["system"] }
 See [the `libffi-sys` documentation] for more information about how it
 finds C libffi.
 
-This crate supports Rust version 1.48 and later.
+This crate supports Rust version 1.78 and later.
 
 ### Examples
 

--- a/libffi-rs/src/lib.rs
+++ b/libffi-rs/src/lib.rs
@@ -38,7 +38,7 @@
 //! See [the `libffi-sys` documentation] for more information about how it
 //! finds C libffi.
 //!
-//! This crate supports Rust version 1.48 and later.
+//! This crate supports Rust version 1.78 and later.
 //!
 //! # Organization
 //!


### PR DESCRIPTION
Ref https://github.com/tov/libffi-rs/pull/112#discussion_r2029370394

Tries bumping MSRV to 1.78