### PR TITLE
Fix out-of-bounds reads on x84-64 for small integers

### DIFF
--- a/libffi-sys-rs/libffi/src/x86/ffi64.c
+++ b/libffi-sys-rs/libffi/src/x86/ffi64.c
@@ -654,7 +654,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 		      break;
 		    default:
 		      reg_args->gpr[gprcount] = 0;
-		      memcpy (&reg_args->gpr[gprcount], a, sizeof(UINT64));
+		      memcpy (&reg_args->gpr[gprcount], a, size <= 8 ? size : 8);
 		    }
 		  gprcount++;
 		  break;


### PR DESCRIPTION
`libffi` performs out-of-bounds reads for arguments of 4 bytes or less on x86-64. This bug also causes `libffi` to ignore zero-extension on x32.

This PR cherry-picks the upstream fix: https://github.com/libffi/libffi/commit/fe203ffbb2bd7f93a86013d341aa767a406150bc