### PR TITLE
Fix various clippy lint warnings

### DIFF
--- a/libffi-rs/src/middle/builder.rs
+++ b/libffi-rs/src/middle/builder.rs
@@ -90,7 +90,7 @@ impl Builder {
     where
         I: IntoIterator<Item = Type>,
     {
-        self.args.extend(types.into_iter());
+        self.args.extend(types);
         self
     }
 

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -156,8 +156,7 @@ unsafe fn ffi_type_clone(old: Type_) -> Owned<Type_> {
             size,
             ..
         } = *old;
-        let new = ffi_type_struct_create_raw(ffi_type_array_clone(elements), size, alignment);
-        new
+        ffi_type_struct_create_raw(ffi_type_array_clone(elements), size, alignment)
     } else {
         old
     }

--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -42,7 +42,7 @@ pub fn build_and_link() {
         Command::new("make")
             .env_remove("DESTDIR")
             .arg("install")
-            .current_dir(&build_dir),
+            .current_dir(build_dir),
     );
 
     // Cargo linking directives
@@ -109,7 +109,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
         command.env(k, v);
     }
 
-    command.current_dir(&build_dir);
+    command.current_dir(build_dir);
 
     if cfg!(windows) {
         // When using MSYS2, OUT_DIR will be a Windows like path such as
@@ -124,7 +124,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
             .to_str()
             .unwrap()
             .replace(":\\", "/")
-            .replace("\\", "/");
+            .replace('\\', "/");
 
         msys_prefix.insert(0, '/');
 

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -119,13 +119,13 @@ pub struct ffi_cif {
     pub is_variadic: c_uint,
     #[cfg(all(target_arch = "aarch64", target_vendor = "apple"))]
     pub aarch64_nfixedargs: c_uint,
-    #[cfg(all(target_arch = "arm"))]
+    #[cfg(target_arch = "arm")]
     pub vfp_used: c_int,
-    #[cfg(all(target_arch = "arm"))]
+    #[cfg(target_arch = "arm")]
     pub vfp_reg_free: c_ushort,
-    #[cfg(all(target_arch = "arm"))]
+    #[cfg(target_arch = "arm")]
     pub vfp_nargs: c_ushort,
-    #[cfg(all(target_arch = "arm"))]
+    #[cfg(target_arch = "arm")]
     pub vfp_args: [c_schar; 16],
     #[cfg(any(target_arch = "powerpc", target_arch = "powerpc64"))]
     pub nfixedargs: c_uint,
@@ -133,9 +133,9 @@ pub struct ffi_cif {
     pub riscv_nfixedargs: c_uint,
     #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
     pub riscv_unused: c_uint,
-    #[cfg(all(target_arch = "loongarch64"))]
+    #[cfg(target_arch = "loongarch64")]
     pub loongarch_nfixedargs: c_uint,
-    #[cfg(all(target_arch = "loongarch64"))]
+    #[cfg(target_arch = "loongarch64")]
     pub loongarch_unused: c_uint,
     #[cfg(any(
         target_arch = "mips",


### PR DESCRIPTION
* Remove redundant `.into_iter()` and references.
* Replace `#[cfg(all(x))]` with `#[cfg(x)]`