### PR TITLE
Add a lifetime to `middle::Arg`

### DIFF
--- a/libffi-rs/src/high/call.rs
+++ b/libffi-rs/src/high/call.rs
@@ -18,7 +18,6 @@
 //! ```
 
 use core::convert::TryInto;
-use core::marker::PhantomData;
 
 use crate::middle;
 pub use middle::CodePtr;
@@ -33,8 +32,7 @@ pub struct Arg<'a> {
     // There should be some type T such that type_ is the middle-layer
     // value of Type<T> and value is T::reify().
     type_: middle::Type,
-    value: middle::Arg,
-    _marker: PhantomData<&'a ()>,
+    value: middle::Arg<'a>,
 }
 
 impl<'a> Arg<'a> {
@@ -45,7 +43,6 @@ impl<'a> Arg<'a> {
         Arg {
             type_: T::reify().into_middle(),
             value: middle::Arg::new(arg),
-            _marker: PhantomData,
         }
     }
 }

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -30,15 +30,18 @@ pub use builder::Builder;
 /// struct accomplishes the necessary coercion.
 #[derive(Clone, Debug)]
 #[repr(C)]
-pub struct Arg(*mut c_void);
+pub struct Arg<'arg>(*mut c_void, PhantomData<&'arg c_void>);
 
-impl Arg {
+impl<'arg> Arg<'arg> {
     /// Coerces an argument reference into the [`Arg`] type.
     ///
     /// This is used to wrap each argument pointer before passing them
     /// to [`Cif::call`].
-    pub fn new<T>(r: &T) -> Self {
-        Arg(r as *const T as *mut c_void)
+    pub fn new<'argument, T>(r: &'argument T) -> Self
+    where
+        'argument: 'arg,
+    {
+        Arg(r as *const T as *mut c_void, PhantomData)
     }
 }
 


### PR DESCRIPTION
`middle::Arg` accepts a reference and turns it into a pointer, throwing away any lifetime information. This pull request adds a a `PhantomData` marker to `middle::Arg` with a lifetime so Rust is able to verify that the provided arguments live long enough.

As demonstrated in the first example in issue #54, it is trivial to write code using `Arg` that can end up pointing to something other than what was intended. The relevant code is:

```rust
let mut args = Vec::new();

for i in 0..num_args {
    args.push(arg(&i));
}
```

Without a lifetime for `Arg`, this will cause undefined behavior. However, with the changes made to `Arg` in this pull request, the example no longer compiles.

I did not find a way to create a meaningful test for this, so I have not included a new test, but this code passes all current tests. The only change is introducing a new lifetime, which I **think** should not be able to introduce new undefined behavior, only possibly rejecting currently working code. In that case the code is *likely* depending on undefined behavior as far as I understand it.