### PR TITLE
Cargo.toml: set rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,10 @@ members = [
     "libffi-rs",
     "libffi-sys-rs",
 ]
+
+[workspace.package]
+repository = "https://github.com/tov/libffi-rs"
+license = "MIT/Apache-2.0"
+keywords = ["ffi", "libffi", "closure", "c"]
+edition = "2018"
+rust-version = "1.78"

--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -3,13 +3,13 @@ name = "libffi"
 version = "4.0.0"
 authors = ["Jesse A. Tov <jesse.tov@gmail.com>"]
 description = "Rust bindings for libffi"
-repository = "https://github.com/tov/libffi-rs"
+repository.workspace = true
 readme = "README.md"
-license = "MIT/Apache-2.0"
-keywords = ["ffi", "libffi", "closure", "c"]
+license.workspace = true
+keywords.workspace = true
 categories = ["development-tools::ffi"]
-edition = "2018"
-rust-version = "1.78"
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 libffi-sys = { path = "../libffi-sys-rs", version = "^3.2" }

--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT/Apache-2.0"
 keywords = ["ffi", "libffi", "closure", "c"]
 categories = ["development-tools::ffi"]
 edition = "2018"
+rust-version = "1.78"
 
 [dependencies]
 libffi-sys = { path = "../libffi-sys-rs", version = "^3.2" }

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Jesse A. Tov <jesse.tov@gmail.com>"]
 links = "ffi"
 build = "build/build.rs"
 description = "Raw Rust bindings for libffi"
-repository = "https://github.com/tov/libffi-rs"
+repository.workspace = true
 readme = "README.md"
-license = "MIT/Apache-2.0"
-keywords = ["ffi", "libffi", "closure", "c"]
-edition = "2018"
-rust-version = "1.78"
+license.workspace = true
+keywords.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 system = []

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT/Apache-2.0"
 keywords = ["ffi", "libffi", "closure", "c"]
 edition = "2018"
+rust-version = "1.78"
 
 [features]
 system = []


### PR DESCRIPTION
This improves diagnostics and dependency resolution.

https://doc.rust-lang.org/stable/cargo/reference/rust-version.html