### PR TITLE
Update edition to 2021 and resolver to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "libffi-rs",
     "libffi-sys-rs",
@@ -8,5 +9,5 @@ members = [
 repository = "https://github.com/tov/libffi-rs"
 license = "MIT/Apache-2.0"
 keywords = ["ffi", "libffi", "closure", "c"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.78"


### PR DESCRIPTION
The MSRV is high enough for this to work.