### PR TITLE
Clippy Linting in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,18 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  cargo-fmt:
+  linting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: "1.78"
-          components: rustfmt
+          components: rustfmt, clippy
       - name: Run rustfmt
         run: 'cargo fmt --all --check'
+      - name: Run clippy
+        run: 'cargo clippy --all-targets --all-features -- -D warnings'
 
   windows-msvc:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run rustfmt
         run: 'cargo fmt --all --check'
       - name: Run clippy
-        run: 'cargo clippy --all-targets --all-features -- -D warnings'
+        run: 'cargo clippy -- -D warnings'
 
   windows-msvc:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run rustfmt
         run: 'cargo fmt --all --check'
       - name: Run clippy
-        run: 'cargo clippy -- -D warnings'
+        run: 'cargo clippy --all-targets -- -D warnings'
 
   windows-msvc:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,14 @@ license = "MIT/Apache-2.0"
 keywords = ["ffi", "libffi", "closure", "c"]
 edition = "2021"
 rust-version = "1.78"
+
+[workspace.lints.clippy]
+complexity = "warn"
+correctness = "warn"
+module_inception = { level = "allow", priority = 1 }
+must_use_candidate = { level = "allow", priority = 1 }
+perf = "warn"
+style = "warn"
+suspicious = "warn"
+unreadable_literal = "warn"
+wildcard_imports = { level = "allow", priority = 1 }

--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -21,3 +21,6 @@ system = ["libffi-sys/system"]
 
 [package.metadata.docs.rs]
 features = ["system"]
+
+[lints]
+workspace = true

--- a/libffi-rs/examples/types.rs
+++ b/libffi-rs/examples/types.rs
@@ -1,5 +1,5 @@
 use libffi::middle::Type;
 
 fn main() {
-    Type::structure(vec![Type::u16(), Type::u16()].into_iter());
+    Type::structure(vec![Type::u16(), Type::u16()]);
 }

--- a/libffi-rs/src/high/call.rs
+++ b/libffi-rs/src/high/call.rs
@@ -74,6 +74,9 @@ pub fn arg<T: super::CType>(arg: &T) -> Arg {
 ///
 /// assert!((result - 5f32).abs() < 0.0001);
 /// ```
+/// # Safety
+/// The signature of the function pointer must match the types of the arguments and the return type.
+/// If the types do not match, we get UB.
 pub unsafe fn call<R: super::CType>(fun: CodePtr, args: &[Arg]) -> R {
     let types = args.iter().map(|arg| arg.type_.clone());
     let cif = middle::Cif::new(types, R::reify().into_middle());

--- a/libffi-rs/src/high/types.rs
+++ b/libffi-rs/src/high/types.rs
@@ -36,6 +36,7 @@ impl<T> Type<T> {
 ///
 /// In particular, for any type `T` that implements `CType`, we can
 /// get a `Type<T>` for describing that type.
+/// # Safety
 /// This trait is unsafe to implement because if the libffi type
 /// associated with a Rust type doesn’t match then we get
 /// undefined behavior.

--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -276,7 +276,7 @@ pub unsafe fn prep_cif(
 /// - `abi` — the calling convention to use
 /// - `nfixedargs` — the number of fixed arguments
 /// - `ntotalargs` — the total number of arguments, including fixed and
-///    var args
+///   var args
 /// - `rtype` — the result type
 /// - `atypes` — the argument types (length must be at least `nargs`)
 ///
@@ -308,7 +308,7 @@ pub unsafe fn prep_cif_var(
 /// # Arguments
 ///
 /// * `cif` — describes the argument and result types and the calling
-///           convention
+///   convention
 /// * `fun` — the function to call
 /// * `args` — the arguments to pass to `fun`
 ///
@@ -476,6 +476,9 @@ pub fn closure_alloc() -> (*mut ffi_closure, CodePtr) {
 ///     closure_free(closure_handle);
 /// }
 /// ```
+/// # Safety
+/// The closure cannot be null and must be a valid pointer to a closure allocated with
+/// [`closure_alloc`].
 pub unsafe fn closure_free(closure: *mut ffi_closure) {
     raw::ffi_closure_free(closure as *mut c_void);
 }
@@ -530,7 +533,7 @@ pub type RawCallback = unsafe extern "C" fn(
 /// - `cif` — the calling convention and types for calling the closure
 /// - `callback` — the function that the closure will invoke
 /// - `userdata` — the closed-over value, stored in the closure and
-///    passed to the callback upon invocation
+///   passed to the callback upon invocation
 /// - `code` — the closure’s code pointer, *i.e.*, the second component
 ///   returned by [`closure_alloc`].
 ///
@@ -622,7 +625,7 @@ pub unsafe fn prep_closure<U, R>(
 /// - `cif` — the calling convention and types for calling the closure
 /// - `callback` — the function that the closure will invoke
 /// - `userdata` — the closed-over value, stored in the closure and
-///    passed to the callback upon invocation
+///   passed to the callback upon invocation
 /// - `code` — the closure’s code pointer, *i.e.*, the second component
 ///   returned by [`closure_alloc`].
 ///

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -464,7 +464,7 @@ mod test {
 
     #[test]
     fn call() {
-        let cif = Cif::new(vec![Type::i64(), Type::i64()].into_iter(), Type::i64());
+        let cif = Cif::new(vec![Type::i64(), Type::i64()], Type::i64());
         let f = |m: i64, n: i64| -> i64 {
             unsafe { cif.call(CodePtr(add_it as *mut c_void), &[arg(&m), arg(&n)]) }
         };
@@ -480,7 +480,7 @@ mod test {
 
     #[test]
     fn closure() {
-        let cif = Cif::new(vec![Type::u64()].into_iter(), Type::u64());
+        let cif = Cif::new(vec![Type::u64()], Type::u64());
         let env: u64 = 5;
         let closure = Closure::new(cif, callback, &env);
 
@@ -502,7 +502,7 @@ mod test {
 
     #[test]
     fn rust_lambda() {
-        let cif = Cif::new(vec![Type::u64(), Type::u64()].into_iter(), Type::u64());
+        let cif = Cif::new(vec![Type::u64(), Type::u64()], Type::u64());
         let env = |x: u64, y: u64| x + y;
         let closure = Closure::new(cif, callback2, &env);
 
@@ -534,8 +534,7 @@ mod test {
                     Type::i64(),
                 ]),
                 Type::u64(),
-            ]
-            .into_iter(),
+            ],
             Type::u64(),
         );
         let clone_cif = cif.clone();

--- a/libffi-rs/src/middle/mod.rs
+++ b/libffi-rs/src/middle/mod.rs
@@ -115,7 +115,7 @@ impl Cif {
         let args = args.into_iter();
         let nargs = args.len();
         let args = types::TypeArray::new(args);
-        let mut cif: low::ffi_cif = Default::default();
+        let mut cif = low::ffi_cif::default();
 
         unsafe {
             low::prep_cif(
@@ -265,7 +265,7 @@ pub struct Closure<'a> {
     _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> Drop for Closure<'a> {
+impl Drop for Closure<'_> {
     fn drop(&mut self) {
         unsafe {
             low::closure_free(self.alloc);

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -156,6 +156,7 @@ unsafe fn ffi_type_clone(old: Type_) -> Owned<Type_> {
             size,
             ..
         } = *old;
+        // Create new
         ffi_type_struct_create_raw(ffi_type_array_clone(elements), size, alignment)
     } else {
         old

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -21,3 +21,6 @@ features = ["system"]
 
 [build-dependencies]
 cc = "1.0"
+
+[lints]
+workspace = true

--- a/libffi-sys-rs/build/common.rs
+++ b/libffi-sys-rs/build/common.rs
@@ -1,20 +1,16 @@
-pub use std::{
-    env, fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+pub use std::{env, fs, process::Command};
 
 #[track_caller]
 pub fn run_command(which: &'static str, cmd: &mut Command) {
     match cmd.status() {
-        Ok(status) if status.success() => return,
+        Ok(status) if status.success() => (),
         Ok(status) => {
-            println!("cargo:warning={} failed with {}", which, status);
-            panic!("{}: {} ({:?})", which, status, cmd);
+            println!("cargo:warning={which} failed with {status}");
+            panic!("{which}: {status} ({cmd:?})");
         }
         Err(err) => {
-            println!("cargo:warning={} failed with error {}", which, err);
-            panic!("{}: {} ({:?})", which, err, cmd);
+            println!("cargo:warning={which} failed with error {err}");
+            panic!("{which}: {err} ({cmd:?})");
         }
     }
 }

--- a/libffi-sys-rs/build/common.rs
+++ b/libffi-sys-rs/build/common.rs
@@ -1,4 +1,8 @@
-pub use std::{env, fs, process::Command};
+pub use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[track_caller]
 pub fn run_command(which: &'static str, cmd: &mut Command) {

--- a/libffi-sys-rs/build/msvc.rs
+++ b/libffi-sys-rs/build/msvc.rs
@@ -19,11 +19,11 @@ const BUILD_FILES_X86_64: &[&str] = &["x86/ffi.c", "x86/ffiw64.c"];
 const BUILD_FILES_AARCH64: &[&str] = &["aarch64/ffi.c"];
 
 fn add_file(build: &mut cc::Build, file: &str) {
-    build.file(format!("libffi/src/{}", file));
+    build.file(format!("libffi/src/{file}"));
 }
 
 fn unsupported(arch: &str) -> ! {
-    panic!("Unsupported architecture: {}", arch)
+    panic!("Unsupported architecture: {arch}")
 }
 
 pub fn build_and_link() {
@@ -83,8 +83,7 @@ pub fn probe_and_link() {
 
 pub fn pre_process_asm(include_dirs: &[&str], target: &str, target_arch: &str) -> String {
     let folder_name = match target_arch {
-        "x86" => "x86",
-        "x86_64" => "x86",
+        "x86" | "x86_64" => "x86",
         "aarch64" => "aarch64",
         _ => unsupported(target_arch),
     };
@@ -111,9 +110,9 @@ pub fn pre_process_asm(include_dirs: &[&str], target: &str, target_arch: &str) -
     }
 
     cmd.arg("/EP");
-    cmd.arg(format!("libffi/src/{}/{}.S", folder_name, file_name));
+    cmd.arg(format!("libffi/src/{folder_name}/{file_name}.S"));
 
-    let out_path = format!("libffi/src/{}/{}.asm", folder_name, file_name);
+    let out_path = format!("libffi/src/{folder_name}/{file_name}.asm");
     let asm_file = fs::File::create(&out_path).expect("Could not create output file");
 
     cmd.stdout(asm_file);

--- a/libffi-sys-rs/src/arch.rs
+++ b/libffi-sys-rs/src/arch.rs
@@ -157,11 +157,11 @@ mod powerpc {
         use crate::ffi_abi;
 
         pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
-        pub const ffi_abi_FFI_SYSV_SOFT_FLOAT: ffi_abi = 0b000001;
-        pub const ffi_abi_FFI_SYSV_STRUCT_RET: ffi_abi = 0b000010;
-        pub const ffi_abi_FFI_SYSV_IBM_LONG_DOUBLE: ffi_abi = 0b000100;
-        pub const ffi_abi_FFI_SYSV: ffi_abi = 0b001000;
-        pub const ffi_abi_FFI_SYSV_LONG_DOUBLE_128: ffi_abi = 0b010000;
+        pub const ffi_abi_FFI_SYSV_SOFT_FLOAT: ffi_abi = 0b00_0001;
+        pub const ffi_abi_FFI_SYSV_STRUCT_RET: ffi_abi = 0b00_0010;
+        pub const ffi_abi_FFI_SYSV_IBM_LONG_DOUBLE: ffi_abi = 0b00_0100;
+        pub const ffi_abi_FFI_SYSV: ffi_abi = 0b00_1000;
+        pub const ffi_abi_FFI_SYSV_LONG_DOUBLE_128: ffi_abi = 0b01_0000;
 
         mod fprs {
             pub const SOFT_FLOAT_FLAG: crate::ffi_abi = 0b0;
@@ -224,10 +224,10 @@ mod powerpc {
         use crate::ffi_abi;
 
         pub const ffi_abi_FFI_FIRST_ABI: ffi_abi = 0;
-        pub const ffi_abi_FFI_LINUX_STRUCT_ALIGN: ffi_abi = 0b000001;
-        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_128: ffi_abi = 0b000010;
-        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_IEEE128: ffi_abi = 0b000100;
-        pub const ffi_abi_FFI_LINUX: ffi_abi = 0b001000;
+        pub const ffi_abi_FFI_LINUX_STRUCT_ALIGN: ffi_abi = 0b00_0001;
+        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_128: ffi_abi = 0b00_0010;
+        pub const ffi_abi_FFI_LINUX_LONG_DOUBLE_IEEE128: ffi_abi = 0b00_0100;
+        pub const ffi_abi_FFI_LINUX: ffi_abi = 0b00_1000;
 
         mod elfv1 {
             pub const STRUCT_ALIGN_FLAG: crate::ffi_abi = 0b0;

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -562,13 +562,13 @@ mod test {
     fn test_function_sign_extension() {
         unsafe {
             let mut cif: ffi_cif = Default::default();
-            let mut arg_types: Vec<*mut ffi_type> = vec![&mut ffi_type_uint8];
+            let mut arg_types: Vec<*mut ffi_type> = vec![addr_of_mut!(ffi_type_uint8)];
 
             let prep_status = ffi_prep_cif(
                 &mut cif,
                 ffi_abi_FFI_DEFAULT_ABI,
                 1,
-                &mut ffi_type_uint32,
+                addr_of_mut!(ffi_type_uint8),
                 arg_types.as_mut_ptr(),
             );
 

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -58,7 +58,7 @@ pub type ffi_abi = u32;
 pub type ffi_status = u32;
 pub type ffi_type_enum = u32;
 
-pub const FFI_64_BIT_MAX: u64 = 9223372036854775807;
+pub const FFI_64_BIT_MAX: u64 = 9_223_372_036_854_775_807;
 pub const FFI_CLOSURES: u32 = 1;
 pub const FFI_SIZEOF_ARG: usize = core::mem::size_of::<c_long>();
 // NOTE: This only differs from FFI_SIZEOF_ARG on ILP platforms, which Rust does not support
@@ -192,7 +192,7 @@ pub struct ffi_closure {
     pub user_data: *mut c_void,
 }
 
-/// Implements Debug manually since sometimes FFI_TRAMPOLINE_SIZE is too large
+/// Implements Debug manually since sometimes `FFI_TRAMPOLINE_SIZE` is too large
 impl Debug for ffi_closure {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ffi_closure")
@@ -238,7 +238,7 @@ pub struct ffi_raw_closure {
     pub user_data: *mut c_void,
 }
 
-/// Implements Debug manually since sometimes FFI_TRAMPOLINE_SIZE is too large
+/// Implements Debug manually since sometimes `FFI_TRAMPOLINE_SIZE` is too large
 impl Debug for ffi_raw_closure {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug_struct = f.debug_struct("ffi_raw_closure");
@@ -291,7 +291,7 @@ pub struct ffi_java_raw_closure {
     pub user_data: *mut c_void,
 }
 
-/// Implements Debug manually since sometimes FFI_TRAMPOLINE_SIZE is too large
+/// Implements Debug manually since sometimes `FFI_TRAMPOLINE_SIZE` is too large
 impl Debug for ffi_java_raw_closure {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut debug_struct = f.debug_struct("ffi_java_raw_closure");


### PR DESCRIPTION
There was an unused import that was just lying around, so fixed a bunch of clippy warnings before enabling it on CI so it can be caught before merge next time.