### PR TITLE
Enable `long double` for all targets

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -132,23 +132,18 @@ pub use raw::{
 /// becomes [`types::void`].
 pub mod types {
     pub use crate::raw::{
-        ffi_type_double as double, ffi_type_float as float, ffi_type_pointer as pointer,
-        ffi_type_sint16 as sint16, ffi_type_sint32 as sint32, ffi_type_sint64 as sint64,
-        ffi_type_sint8 as sint8, ffi_type_uint16 as uint16, ffi_type_uint32 as uint32,
-        ffi_type_uint64 as uint64, ffi_type_uint8 as uint8, ffi_type_void as void,
+        ffi_type_double as double, ffi_type_float as float, ffi_type_longdouble as longdouble,
+        ffi_type_pointer as pointer, ffi_type_sint16 as sint16, ffi_type_sint32 as sint32,
+        ffi_type_sint64 as sint64, ffi_type_sint8 as sint8, ffi_type_uint16 as uint16,
+        ffi_type_uint32 as uint32, ffi_type_uint64 as uint64, ffi_type_uint8 as uint8,
+        ffi_type_void as void,
     };
-
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    pub use crate::raw::ffi_type_longdouble as longdouble;
 
     #[cfg(feature = "complex")]
     pub use crate::raw::{
         ffi_type_complex_double as complex_double, ffi_type_complex_float as complex_float,
+        ffi_type_complex_longdouble as complex_longdouble,
     };
-
-    #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm")))]
-    pub use crate::raw::ffi_type_complex_longdouble as complex_longdouble;
 }
 
 /// Type tags used in constructing and inspecting [`ffi_type`]s.

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -381,7 +381,6 @@ impl Type {
     }
 
     /// Returns the C `long double` (extended-precision floating point) type.
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
     pub fn longdouble() -> Self {
         Type(unsafe { Unique::new(addr_of_mut!(low::types::longdouble)) })
     }
@@ -406,7 +405,6 @@ impl Type {
     ///
     /// This item is enabled by `#[cfg(feature = "complex")]`.
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm")))]
     pub fn complex_longdouble() -> Self {
         Type(unsafe { Unique::new(addr_of_mut!(low::types::complex_longdouble)) })
     }

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -421,11 +421,8 @@ extern "C" {
     pub static mut ffi_type_sint64: ffi_type;
     pub static mut ffi_type_float: ffi_type;
     pub static mut ffi_type_double: ffi_type;
-    pub static mut ffi_type_pointer: ffi_type;
-
-    #[cfg(not(target_arch = "aarch64"))]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
     pub static mut ffi_type_longdouble: ffi_type;
+    pub static mut ffi_type_pointer: ffi_type;
 
     #[cfg(feature = "complex")]
     pub static mut ffi_type_complex_float: ffi_type;
@@ -434,7 +431,6 @@ extern "C" {
     pub static mut ffi_type_complex_double: ffi_type;
 
     #[cfg(feature = "complex")]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
     pub static mut ffi_type_complex_longdouble: ffi_type;
 
     pub fn ffi_raw_call(


### PR DESCRIPTION
Since [libffi v3.4.6](https://github.com/libffi/libffi/commit/cd78b539125ae615d76df5a57039fe70ebd56c27), `long double` types have been defined for all targets. This pull request exposes `long double` types for all targets from libffi-rs as well.

This is not a breaking change, but it would still constitute a minor version bump as far as I understand. Let me know if you want me to target the "next" branch instead.

There are no tests for `long double` as they are (mostly) not really supported by Rust. It is currently possible to write tests for targets where `long double` is the same size as double (MSVC, ARMv7 and some PPC configurations?). Further targets should be supported when/if [`f128` is stabilized](https://github.com/rust-lang/rust/issues/116909). For x86(_64) I cannot see that there are any concrete plans to enable support for a `f80` type.

Should `long double`s be tested? Eventually kept as they are now (available, but without further support), removed from libffi-rs entirely, or removed from `middle::Type` as they are not available from Rust? ~~This question might deserve its own issue.~~ I created [an issue to discuss how `long double`s should be handled in libffi-rs](https://github.com/tov/libffi-rs/issues/131).