### PR TITLE
Add no_std support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
         toolchain:
           - 1.78.0
           - stable
+        features:
+          - "--no-default-features"
+          - "--features std"
+          - "--features std,system"
     runs-on: windows-latest
     name: windows-msvc ${{ matrix.toolchain }}
     steps:
@@ -35,7 +39,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
-        run: cargo test
+        run: cargo test ${{ matrix.features }}
 
   windows-gnu:
     strategy:
@@ -44,6 +48,10 @@ jobs:
         toolchain:
           - 1.78.0-gnu
           - stable-gnu
+        features:
+          - "--no-default-features"
+          - "--features std"
+          - "--features std,system"
     runs-on: windows-latest
     name: windows-gnu ${{ matrix.toolchain }}
     steps:
@@ -58,7 +66,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Run tests
         shell: msys2 {0}
-        run: cargo test
+        run: cargo test ${{ matrix.features }}
 
   macos:
     strategy:
@@ -72,7 +80,8 @@ jobs:
           - stable
         features:
           - "--no-default-features"
-          - "--features system"
+          - "--features std"
+          - "--features std,system"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.runner }} ${{ matrix.toolchain }} ${{ matrix.features }}
     steps:
@@ -97,7 +106,8 @@ jobs:
           - stable
         features:
           - "--no-default-features"
-          - "--features system"
+          - "--features std"
+          - "--features std,system"
     runs-on: ubuntu-latest
     name: ${{ matrix.runner }} ${{ matrix.toolchain }} ${{ matrix.features }}
     steps:

--- a/libffi-rs/Cargo.toml
+++ b/libffi-rs/Cargo.toml
@@ -12,15 +12,17 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-libffi-sys = { path = "../libffi-sys-rs", version = "^3.2" }
+libffi-sys = { path = "../libffi-sys-rs", version = "^3.2", default-features = false }
 libc = "0.2.65"
 
 [features]
 complex = []
+default = ["std"]
+std = ["libffi-sys/std"]
 system = ["libffi-sys/system"]
 
 [package.metadata.docs.rs]
-features = ["system"]
+features = ["std", "system"]
 
 [lints]
 workspace = true

--- a/libffi-rs/src/high/call.rs
+++ b/libffi-rs/src/high/call.rs
@@ -81,7 +81,10 @@ pub unsafe fn call<R: super::CType>(fun: CodePtr, args: &[Arg]) -> R {
     let types = args.iter().map(|arg| arg.type_.clone());
     let cif = middle::Cif::new(types, R::reify().into_middle());
 
-    let values = args.iter().map(|arg| arg.value.clone()).collect::<Vec<_>>();
+    let values = args
+        .iter()
+        .map(|arg| arg.value.clone())
+        .collect::<alloc::vec::Vec<_>>();
     // If `R` is a small integer type, libffi implicitly extends it to
     // `ffi_arg` or `ffi_sarg`.  To account for this, use `R::RetType`
     // as return type for the low-level call, and convert the result back.

--- a/libffi-rs/src/high/mod.rs
+++ b/libffi-rs/src/high/mod.rs
@@ -129,7 +129,7 @@ macro_rules! define_closure_mod {
                 #[allow(non_snake_case)]
                 pub fn new($( $T: Type<$T>, )* result: Type<R>) -> Self {
                     let cif = middle::Cif::new(
-                        vec![$( $T.into_middle() ),*].into_iter(),
+                        std::vec![$( $T.into_middle() ),*].into_iter(),
                         result.into_middle());
                     $cif { untyped: cif, _marker: PhantomData }
                 }

--- a/libffi-rs/src/high/types.rs
+++ b/libffi-rs/src/high/types.rs
@@ -49,7 +49,7 @@ pub unsafe trait CType: Copy {
     /// The low-level libffi library implicitly extends small integer
     /// return values to `ffi_arg` or `ffi_sarg`.  Track the possibly
     /// extended variant of `T` as an associated type here.
-    type RetType: std::convert::From<Self> + std::convert::TryInto<Self>;
+    type RetType: core::convert::From<Self> + core::convert::TryInto<Self>;
 }
 
 macro_rules! impl_ffi_type {

--- a/libffi-rs/src/lib.rs
+++ b/libffi-rs/src/lib.rs
@@ -87,6 +87,11 @@
 //!
 
 #![deny(missing_docs)]
+#![no_std]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 /// Raw definitions imported from the C library (via bindgen).
 ///

--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -690,7 +690,7 @@ pub unsafe fn prep_closure_mut<U, R>(
     status_to_result(status, ())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use std::ptr::{addr_of_mut, null_mut};
 

--- a/libffi-rs/src/middle/builder.rs
+++ b/libffi-rs/src/middle/builder.rs
@@ -58,7 +58,7 @@ use super::types::Type;
 /// ```
 #[derive(Clone, Debug)]
 pub struct Builder {
-    args: Vec<Type>,
+    args: alloc::vec::Vec<Type>,
     res: Type,
     abi: super::FfiAbi,
 }
@@ -73,7 +73,7 @@ impl Builder {
     /// Constructs a `Builder`.
     pub fn new() -> Self {
         Builder {
-            args: vec![],
+            args: alloc::vec![],
             res: Type::void(),
             abi: super::ffi_abi_FFI_DEFAULT_ABI,
         }

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -6,11 +6,11 @@
 //! and a result type, and libffi uses this to figure out how to set up
 //! a call to a function with those types.
 
+use core::fmt;
 use core::mem;
 use core::ptr;
 use core::ptr::addr_of_mut;
 use libc;
-use std::fmt;
 
 use crate::low;
 
@@ -449,7 +449,7 @@ impl TypeArray {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use super::*;
 
@@ -465,12 +465,12 @@ mod test {
 
     #[test]
     fn create_struct() {
-        Type::structure(vec![Type::i64(), Type::i64(), Type::u64()]);
+        Type::structure(alloc::vec![Type::i64(), Type::i64(), Type::u64()]);
     }
 
     #[test]
     fn clone_struct() {
-        let _ = Type::structure(vec![Type::i64(), Type::i64(), Type::u64()])
+        let _ = Type::structure(alloc::vec![Type::i64(), Type::i64(), Type::u64()])
             .clone()
             .clone();
     }

--- a/libffi-sys-rs/Cargo.toml
+++ b/libffi-sys-rs/Cargo.toml
@@ -13,11 +13,13 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
+default = ["std"]
+std = []
 system = []
 complex = []
 
 [package.metadata.docs.rs]
-features = ["system"]
+features = ["std", "system"]
 
 [build-dependencies]
 cc = "1.0"

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -50,6 +50,10 @@
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
 #![allow(unused_imports)]
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::ffi::{c_char, c_int, c_long, c_schar, c_uint, c_ulong, c_ushort, c_void};
 use core::fmt::{self, Debug, Formatter};
@@ -623,9 +627,10 @@ extern "C" {
     ) -> ffi_status;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use std::{mem::transmute, ptr::addr_of_mut};
+    use std::{vec, vec::Vec};
 
     use super::*;
 


### PR DESCRIPTION
Due to how features work this would break anyone's `Cargo.toml` with `default-features = false`, so I have to target next.

Fixes: #84 