### PR TITLE
Remove duplicate `long double` symbols

### DIFF
--- a/libffi-rs/src/low.rs
+++ b/libffi-rs/src/low.rs
@@ -139,18 +139,11 @@ pub mod types {
         ffi_type_void as void,
     };
 
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    pub use crate::raw::ffi_type_longdouble as longdouble;
-
     #[cfg(all(feature = "complex", not(windows)))]
     pub use crate::raw::{
         ffi_type_complex_double as complex_double, ffi_type_complex_float as complex_float,
         ffi_type_complex_longdouble as complex_longdouble,
     };
-
-    #[cfg(all(feature = "complex", not(windows)))]
-    #[cfg(not(all(target_arch = "arm")))]
-    pub use crate::raw::ffi_type_complex_longdouble as complex_longdouble;
 }
 
 /// Type tags used in constructing and inspecting [`ffi_type`]s.

--- a/libffi-rs/src/middle/types.rs
+++ b/libffi-rs/src/middle/types.rs
@@ -405,7 +405,6 @@ impl Type {
     ///
     /// This item is enabled by `#[cfg(all(feature = "complex", not(windows)))]`.
     #[cfg(all(feature = "complex", not(windows)))]
-    #[cfg(not(all(target_arch = "arm")))]
     pub fn complex_longdouble() -> Self {
         Type(unsafe { Unique::new(addr_of_mut!(low::types::complex_longdouble)) })
     }

--- a/libffi-sys-rs/src/lib.rs
+++ b/libffi-sys-rs/src/lib.rs
@@ -442,7 +442,6 @@ extern "C" {
     pub static mut ffi_type_complex_double: ffi_type;
 
     #[cfg(all(feature = "complex", not(windows)))]
-    #[cfg(not(all(target_arch = "arm", target_os = "linux", target_env = "gnu")))]
     pub static mut ffi_type_complex_longdouble: ffi_type;
 
     pub fn ffi_raw_call(


### PR DESCRIPTION
Removes duplicate definitions of the following symbols:

* `libffi_sys::ffi_type_complex_longdouble`
* `libffi::middle::types::longdouble`
* `libffi::middle::types::complex_longdouble`
* `libffi::middle::Type::complex_longdouble`