### PR TITLE
Replace `set_abi` functions for cifs

### DIFF
--- a/libffi-rs/src/high/mod.rs
+++ b/libffi-rs/src/high/mod.rs
@@ -155,15 +155,19 @@ macro_rules! define_closure_mod {
                 /// and result types.
                 #[allow(non_snake_case)]
                 pub fn new($( $T: Type<$T>, )* result: Type<R>) -> Self {
-                    let cif = middle::Cif::new(
-                        alloc::vec![$( $T.into_middle() ),*].into_iter(),
-                        result.into_middle());
-                    $cif { untyped: cif, _marker: PhantomData }
+                    Self::new_with_abi($($T, )* result, ffi_abi_FFI_DEFAULT_ABI)
                 }
 
-                /// Sets the CIF to use the given calling convention.
-                pub fn set_abi(&mut self, abi: FfiAbi) {
-                    self.untyped.set_abi(abi);
+                /// Creates a new statically-typed CIF with the given argument
+                /// and result types for the specified ABI.
+                #[allow(non_snake_case)]
+                pub fn new_with_abi($( $T: Type<$T>, )* result: Type<R>, abi: FfiAbi) -> Self {
+                    let cif = middle::Cif::new_with_abi(
+                        alloc::vec![$( $T.into_middle() ),*].into_iter(),
+                        result.into_middle(),
+                        abi,
+                    );
+                    $cif { untyped: cif, _marker: PhantomData }
                 }
             }
 

--- a/libffi-rs/src/middle/builder.rs
+++ b/libffi-rs/src/middle/builder.rs
@@ -108,9 +108,7 @@ impl Builder {
 
     /// Builds a CIF.
     pub fn into_cif(self) -> super::Cif {
-        let mut result = super::Cif::new(self.args, self.res);
-        result.set_abi(self.abi);
-        result
+        super::Cif::new_with_abi(self.args, self.res, self.abi)
     }
 
     /// Builds an immutable closure.


### PR DESCRIPTION
Cifs in the middle and high modules had a `set_abi` function to set a non-default ABI. This is not necessarily safe as the ABI is used for initializing a cif in `ffi_prep_cif`. Changing the ABI after initialization may cause problems when calling a function using the cif.

This PR replaces the `set_abi` functions with `_with_abi` variants for cif constructors (`new` and `new_variadic`).

This change is breaking as `set_abi` functions are removed. A non-breaking version would have to call `ffi_prep_cif` again after setting the ABI. For normal CIFs this is possible using the information store in the `middle::Cif` and `low::ffi_cif`, but for variadic cifs, a new field with the number of fixed arguments will need to be added to `middle::Cif` to ensure that it works on all platforms.

Overall, I think it is better to specify the ABI once when creating the cifs and avoid multiple calls to `ffi_prep_cif`, but if you want to avoid this breaking change, I can have a go at creating versions of `set_abi` that calls `ffi_prep_cif` again after changing the ABI.