### PR TITLE
use GNU make on illumos as well

### DIFF
--- a/libffi-sys-rs/build/not_msvc.rs
+++ b/libffi-sys-rs/build/not_msvc.rs
@@ -41,7 +41,7 @@ pub fn build_and_link() {
     // Generate configure, run configure, make, make install
     configure_libffi(prefix, &build_dir);
 
-    let make_command = if cfg!(target_os = "aix") {
+    let make_command = if cfg!(target_os = "aix") || cfg!(target_os = "illumos") {
         "gmake"
     } else {
         "make"
@@ -151,7 +151,7 @@ pub fn configure_libffi(prefix: PathBuf, build_dir: &Path) {
         command.arg("--prefix").arg(prefix);
     }
 
-    if cfg!(target_os = "aix") {
+    if cfg!(target_os = "aix") || cfg!(target_os = "illumos") {
         command.env("MAKE", "gmake");
     }
 


### PR DESCRIPTION
in the same spirit as https://github.com/libffi-rs/libffi-rs/pull/104, illumos' `make` is also not GNU make, so configuring `libffi` fails with the (helpful!) text:

```
  config.status: error: Something went wrong bootstrapping makefile fragments
      for automatic dependency tracking.  If GNU make was not used, consider
      re-running the configure script with MAKE="gmake" [...]
```

while rebuilding with `export MAKE=gmake` (with gmake installed) gets the job done, it would be nice to pick the right `make` out of the box.

since at the point https://github.com/libffi-rs/libffi-rs/pull/59 merged `libffi-rs` built fine on illumos, i suspect (but haven't checked) the move from libffi 3.4.2 to 3.4.4 included some change that wants GNU make specifically.

(i should perhaps mention that BSDs and Solaris-likes probably have a default `make` which `libffi` won't like configuring with either, but i've definitely not looked beyond just illumos.)