### PR TITLE
Fix xwin clang-cl cross compilation

### DIFF
--- a/libffi-sys-rs/build/msvc.rs
+++ b/libffi-sys-rs/build/msvc.rs
@@ -62,6 +62,10 @@ pub fn build_and_link() {
         .file_name()
         .and_then(|n| n.to_str())
         .is_some_and(|n| n.contains("clang"));
+    if is_clang_cl {
+        // dlmalloc's lock is an `int` while the Windows interlocked intrinsics expect `volatile long *`
+        build.flag_if_supported("-Wno-error=incompatible-pointer-types");
+    }
     if is_clang_cl && target_arch == "x86_64" {
         let out_dir = env::var("OUT_DIR").unwrap();
         let obj = format!("{out_dir}/win64_gnu.obj");


### PR DESCRIPTION
Compiling with `clang-cl` version 22.1.6 targeting `x86_64-pc-windows-msvc` currently results in an incompatible pointer type error preventing it from building

```
  cargo:warning=In file included from libffi/src/closures.c:570:
  cargo:warning=libffi/src/dlmalloc.c(1956,45): error: incompatible pointer types passing 'int *' to parameter of type 'volatile long *' [-Wincompatible-pointer-types]
  cargo:warning= 1956 |   while (ffi_spin_peek(sl) != 0 || CAS_LOCK(sl)) {
  cargo:warning=      |                                             ^~
  cargo:warning=/home/truman/.cache/cargo-xwin/xwin/sdk/include/um/winnt.h(3130,50): note: passing argument to parameter 'Target' here
  cargo:warning= 3130 |     _Inout_ _Interlocked_operand_ LONG volatile *Target,
  cargo:warning=      |                                                  ^
```